### PR TITLE
Refactor package setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.253
+    rev: v0.0.254
     hooks:
       - id: ruff
         args: [--fix]

--- a/chgnet/__init__.py
+++ b/chgnet/__init__.py
@@ -1,2 +1,8 @@
 """The pytorch implementation for CHGNet neural network potential."""
-__version__ = "0.0.1"
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__name__)  # read from setup.py
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/chgnet/graph/__init__.py
+++ b/chgnet/graph/__init__.py
@@ -1,4 +1,4 @@
-from .crystalgraph import CrystalGraph, CrystalGraphConverter
-from .graph import Graph, Node
+from chgnet.crystalgraph import CrystalGraph, CrystalGraphConverter
+from chgnet.graph import Graph, Node
 
 __all__ = ["CrystalGraph", "CrystalGraphConverter", "Graph", "Node"]

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from pymatgen.core.structure import Structure
 from torch import Tensor
 
-from .graph import Graph, Node
+from chgnet.graph import Graph, Node
 
 datatype = torch.float32
 

--- a/chgnet/model/__init__.py
+++ b/chgnet/model/__init__.py
@@ -1,4 +1,4 @@
-from .model import CHGNet        # noqa
-from .dynamics import CHGNetCalculator, MolecularDynamics, StructOptimizer
+from chgnet.model import CHGNet  # noqa
+from chgnet.dynamics import CHGNetCalculator, MolecularDynamics, StructOptimizer
 
 __all__ = ["CHGNet", "StructOptimizer", "MolecularDynamics", "CHGNetCalculator"]

--- a/chgnet/trainer/__init__.py
+++ b/chgnet/trainer/__init__.py
@@ -1,3 +1,3 @@
-from .trainer import Trainer
+from chgnet.trainer import Trainer
 
 __all__ = ["Trainer"]

--- a/chgnet/utils/__init__.py
+++ b/chgnet/utils/__init__.py
@@ -1,3 +1,3 @@
-from .utils import AverageMeter, mae, mkdir, read_json, write_json
+from chgnet.utils import AverageMeter, mae, mkdir, read_json, write_json
 
 __all__ = ["AverageMeter", "mae", "mkdir", "read_json", "write_json"]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 """
 import os
 
-from setuptools import find_namespace_packages, setup
+from setuptools import find_packages, setup
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         author=["Bowen Deng"],
         author_email=["bowendeng@berkeley.edu"],
         license="MIT",
-        packages=find_namespace_packages(),
+        packages=find_packages(),
         package_data={"chgnet": ["chgnet/pretrained/*"]},
         include_package_data=True,
         include_dirs=["pretrained"],

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,16 @@
 @author: Bowen Deng.
 """
 import os
-import re
 
 from setuptools import find_namespace_packages, setup
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 
-with open("chgnet/__init__.py", encoding="utf-8") as fd:
-    try:
-        lines = ""
-        for item in fd.readlines():
-            item = item
-            lines += item + "\n"
-    except Exception as exc:
-        raise Exception(f"Caught exception {exc}")
-version = re.search('__version__ = "(.*)"', lines).group(1)
 
 if __name__ == "__main__":
     setup(
         name="chgnet",
-        version=version,
+        version="0.0.1",
         description="Pretrained Neural Network Potential for Charge-informed Molecular Dynamics",
         long_description=open(os.path.join(module_dir, "README.md")).read(),
         url="https://github.com/BowenD-UCB/chgnet",


### PR DESCRIPTION
- Move the source of truth for the version number from `chgnet/__init__.py` to `setup.py`.

   Use `importlib.metadata.version` to read it from there. Part of the Python std lib since 3.8 and the recommended way to retrieve package version information.

- Replace `setuptools.find_namespace_packages` with `find_packages` since you're actually not using namespace packages (see https://youtu.be/2Xvb79hOUdM for a good explainer)