### PR TITLE
Use future type annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: 3.8
           cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install dependencies
         run: |

--- a/chgnet/__init__.py
+++ b/chgnet/__init__.py
@@ -1,5 +1,7 @@
 """The pytorch implementation for CHGNet neural network potential."""
 
+from __future__ import annotations
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import functools
 import os
 import random
 import warnings
-from typing import List, Literal, Union
+from typing import Literal
 
 import numpy as np
 import torch
@@ -22,11 +24,11 @@ class StructureData(Dataset):
 
     def __init__(
         self,
-        structures: List,
-        energies: List,
-        forces: List,
-        stresses: List = None,
-        magmoms: List = None,
+        structures: list,
+        energies: list,
+        forces: list,
+        stresses: list = None,
+        magmoms: list = None,
         graph_converter: CrystalGraphConverter = None,
     ):
         """Initialize the dataset.
@@ -113,7 +115,7 @@ class CIFData(Dataset):
     def __init__(
         self,
         cif_path: str,
-        labels: Union[str, dict] = "labels.json",
+        labels: str | dict = "labels.json",
         targets: Literal["ef", "efs", "efsm"] = "ef",
         graph_converter: CrystalGraphConverter = None,
         **kwargs,
@@ -214,9 +216,9 @@ class GraphData(Dataset):
     def __init__(
         self,
         graph_path: str,
-        labels: Union[str, dict] = "labels.json",
+        labels: str | dict = "labels.json",
         targets: str = "efsm",
-        exclude: Union[str, list] = None,
+        exclude: str | list = None,
         **kwargs,
     ):
         """Initialize the dataset from a directory containing saved crystal graphs.
@@ -311,9 +313,9 @@ class GraphData(Dataset):
         self,
         train_ratio: float = 0.8,
         val_ratio: float = 0.1,
-        train_key: List[str] = None,
-        val_key: List[str] = None,
-        test_key: List[str] = None,
+        train_key: list[str] = None,
+        val_key: list[str] = None,
+        test_key: list[str] = None,
         batch_size=32,
         num_workers=0,
         pin_memory=True,
@@ -426,7 +428,7 @@ class StructureJsonData(Dataset):
 
     def __init__(
         self,
-        data: Union[str, dict],
+        data: str | dict,
         graph_converter: CrystalGraphConverter,
         targets: Literal["ef", "efs", "efsm"] = "efsm",
         **kwargs,
@@ -521,9 +523,9 @@ class StructureJsonData(Dataset):
         self,
         train_ratio: float = 0.8,
         val_ratio: float = 0.1,
-        train_key: List[str] = None,
-        val_key: List[str] = None,
-        test_key: List[str] = None,
+        train_key: list[str] = None,
+        val_key: list[str] = None,
+        test_key: list[str] = None,
         batch_size=32,
         num_workers=0,
         pin_memory=True,
@@ -613,7 +615,7 @@ class StructureJsonData(Dataset):
         return train_loader, val_loader, test_loader
 
 
-def collate_graphs(batch_data: List):
+def collate_graphs(batch_data: list):
     """Collate of list of (graph, target) into batch data,.
 
     Args:

--- a/chgnet/graph/__init__.py
+++ b/chgnet/graph/__init__.py
@@ -1,4 +1,6 @@
-from chgnet.crystalgraph import CrystalGraph, CrystalGraphConverter
-from chgnet.graph import Graph, Node
+from __future__ import annotations
+
+from chgnet.graph.crystalgraph import CrystalGraph, CrystalGraphConverter
+from chgnet.graph.graph import Graph, Node
 
 __all__ = ["CrystalGraph", "CrystalGraphConverter", "Graph", "Node"]

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import Literal

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 from pymatgen.core.structure import Structure
 from torch import Tensor
 
-from chgnet.graph import Graph, Node
+from chgnet.graph.graph import Graph, Node
 
 datatype = torch.float32
 

--- a/chgnet/graph/graph.py
+++ b/chgnet/graph/graph.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from chgnet import utils
 
@@ -26,7 +26,7 @@ class Node:
 class UndirectedEdge:
     """An edge in a graph."""
 
-    def __init__(self, nodes: List, index: int = None, info: dict = None):
+    def __init__(self, nodes: list, index: int = None, info: dict = None):
         self.nodes = nodes
         self.index = index
         self.info = info
@@ -46,7 +46,7 @@ class UndirectedEdge:
 class DirectedEdge:
     """An edge in a graph."""
 
-    def __init__(self, nodes: List, index: int, info: dict = None):
+    def __init__(self, nodes: list, index: int, info: dict = None):
         self.nodes = nodes
         self.index = index
         self.info = info

--- a/chgnet/model/__init__.py
+++ b/chgnet/model/__init__.py
@@ -1,4 +1,6 @@
-from chgnet.model import CHGNet  # noqa
-from chgnet.dynamics import CHGNetCalculator, MolecularDynamics, StructOptimizer
+from __future__ import annotations
+
+from chgnet.model.dynamics import CHGNetCalculator, MolecularDynamics, StructOptimizer
+from chgnet.model.model import CHGNet
 
 __all__ = ["CHGNet", "StructOptimizer", "MolecularDynamics", "CHGNetCalculator"]

--- a/chgnet/model/basis.py
+++ b/chgnet/model/basis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import collections
-from typing import List
 
 import numpy as np
 import torch
@@ -46,11 +47,11 @@ class Composition_model(nn.Module):
         composition_feas = composition_feas + self.gated_mlp(composition_feas)
         return self.fc2(composition_feas).view(-1)
 
-    def forward(self, graphs: List[CrystalGraph]):
+    def forward(self, graphs: list[CrystalGraph]):
         composition_feas = self._assemble_graphs(graphs)
         return self._get_energy(composition_feas)
 
-    def _assemble_graphs(self, graphs: List[CrystalGraph]):
+    def _assemble_graphs(self, graphs: list[CrystalGraph]):
         """Assemble a list of graphs into one-hot composition encodings
         Args:
             graphs (List[Tensor]): a list of Crystal_Graphs
@@ -81,7 +82,7 @@ class Atom_Ref(nn.Module):
         self.fc = nn.Linear(max_num_elements, 1, bias=False)
         self.fitted = False
 
-    def forward(self, graphs: List[CrystalGraph]):
+    def forward(self, graphs: list[CrystalGraph]):
         """get the energy of a list of Crystal_Graphs.
 
         Args:
@@ -139,7 +140,7 @@ class Atom_Ref(nn.Module):
         self.fc.load_state_dict(state_dict)
         self.fitted = True
 
-    def _assemble_graphs(self, graphs: List[CrystalGraph]):
+    def _assemble_graphs(self, graphs: list[CrystalGraph]):
         """Assemble a list of graphs into one-hot composition encodings
         Args:
             graphs (List[Tensor]): a list of Crystal_Graphs

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -23,7 +23,7 @@ from ase.optimize.sciopt import SciPyFminBFGS, SciPyFminCG
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 
-from chgnet.model import CHGNet
+from chgnet.model.model import CHGNet
 
 # We would like to thank M3GNet develop team for this module
 # source: https://github.com/materialsvirtuallab/m3gnet

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import contextlib
 import io
 import pickle
 import sys
-from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -46,9 +47,9 @@ class CHGNetCalculator(Calculator):
 
     def __init__(
         self,
-        model: Optional[CHGNet] = None,
-        use_device: Optional[str] = None,
-        stress_weight: Optional[float] = 1 / 160.21766208,
+        model: CHGNet | None = None,
+        use_device: str | None = None,
+        stress_weight: float | None = 1 / 160.21766208,
         **kwargs,
     ):
         """Provide a CHGNet instance to calculate various atomic properties using ASE.
@@ -81,9 +82,9 @@ class CHGNetCalculator(Calculator):
 
     def calculate(
         self,
-        atoms: Optional[Atoms] = None,
-        desired_properties: Optional[list] = None,
-        changed_properties: Optional[list] = None,
+        atoms: Atoms | None = None,
+        desired_properties: list | None = None,
+        changed_properties: list | None = None,
     ):
         """Calculate various properties of the atoms using CHGNet.
 
@@ -127,7 +128,7 @@ class StructOptimizer:
     def __init__(
         self,
         model: CHGNet = None,
-        optimizer_class: Optional[Union[Optimizer, str]] = "FIRE",
+        optimizer_class: Optimizer | str | None = "FIRE",
         use_device: str = None,
         stress_weight: float = 1 / 160.21766208,
     ) -> None:
@@ -158,12 +159,12 @@ class StructOptimizer:
 
     def relax(
         self,
-        atoms: Union[Structure, Atoms],
-        fmax: Optional[float] = 0.1,
-        steps: Optional[int] = 500,
-        relax_cell: Optional[bool] = True,
-        save_path: Optional[str] = None,
-        trajectory_save_interval: Optional[int] = 1,
+        atoms: Structure | Atoms,
+        fmax: float | None = 0.1,
+        steps: int | None = 500,
+        relax_cell: bool | None = True,
+        save_path: str | None = None,
+        trajectory_save_interval: int | None = 1,
         verbose: bool = True,
         **kwargs,
     ):
@@ -287,17 +288,17 @@ class MolecularDynamics:
 
     def __init__(
         self,
-        atoms: Union[Atoms, Structure],
+        atoms: Atoms | Structure,
         model: CHGNet = None,
         ensemble: str = "nvt",
         temperature: int = 300,
         timestep: float = 2.0,
         pressure: float = 1.01325 * units.bar,
-        taut: Optional[float] = None,
-        taup: Optional[float] = None,
-        compressibility_au: Optional[float] = None,
-        trajectory: Optional[Union[str, Trajectory]] = None,
-        logfile: Optional[str] = None,
+        taut: float | None = None,
+        taup: float | None = None,
+        compressibility_au: float | None = None,
+        trajectory: str | Trajectory | None = None,
+        logfile: str | None = None,
         loginterval: int = 1,
         append_trajectory: bool = False,
         use_device: str = None,

--- a/chgnet/model/encoders.py
+++ b/chgnet/model/encoders.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 from torch import Tensor

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from __future__ import annotations
 
 import torch
 import torch.nn as nn
@@ -46,7 +46,7 @@ class MLP(nn.Module):
         self,
         input_dim: int = None,
         output_dim: int = 1,
-        hidden_dim: Union[List[int], int] = [64, 64],
+        hidden_dim: list[int] | int = [64, 64],
         dropout=0,
         activation="silu",
     ):
@@ -102,7 +102,7 @@ class GatedMLP(nn.Module):
         self,
         input_dim: int = None,
         output_dim: int = None,
-        hidden_dim: Union[int, List[int]] = None,
+        hidden_dim: int | list[int] = None,
         dropout=0,
         activation="silu",
         norm="batch",

--- a/chgnet/model/layers.py
+++ b/chgnet/model/layers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -24,7 +26,7 @@ class AtomConv(nn.Module):
         norm: str = None,
         use_mlp_out: bool = True,
         resnet: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.
@@ -138,7 +140,7 @@ class BondConv(nn.Module):
         norm: str = None,
         use_mlp_out: bool = True,
         resnet=True,
-        **kwargs
+        **kwargs,
     ):
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.
@@ -256,7 +258,7 @@ class AngleUpdate(nn.Module):
         activation: str = "silu",
         norm: str = None,
         resnet: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import math
 import os
-from typing import Literal, Sequence, Union
+from typing import Literal, Sequence
 
 import torch
 import torch.nn as nn
@@ -36,14 +38,14 @@ class CHGNet(nn.Module):
         num_radial: int = 9,
         num_angular: int = 9,
         n_conv: int = 4,
-        atom_conv_hidden_dim: Union[Sequence[int], int] = 64,
+        atom_conv_hidden_dim: Sequence[int] | int = 64,
         update_bond: bool = True,
-        bond_conv_hidden_dim: Union[Sequence[int], int] = 64,
+        bond_conv_hidden_dim: Sequence[int] | int = 64,
         update_angle: bool = True,
-        angle_layer_hidden_dim: Union[Sequence[int], int] = 0,
+        angle_layer_hidden_dim: Sequence[int] | int = 0,
         conv_dropout: float = 0,
         read_out: str = "ave",
-        mlp_hidden_dims: Union[Sequence[int], int] = (64, 64),
+        mlp_hidden_dims: Sequence[int] | int = (64, 64),
         mlp_dropout: float = 0,
         mlp_first: bool = True,
         is_intensive: bool = True,
@@ -474,7 +476,7 @@ class CHGNet(nn.Module):
 
     def predict_structure(
         self,
-        structure: Union[Structure, Sequence[Structure]],
+        structure: Structure | Sequence[Structure],
         task: str = "efsm",
         return_atom_feas: bool = False,
         return_crystal_feas: bool = False,
@@ -528,7 +530,7 @@ class CHGNet(nn.Module):
 
     def predict_graph(
         self,
-        graph: Union[CrystalGraph, Sequence[CrystalGraph]],
+        graph: CrystalGraph | Sequence[CrystalGraph],
         task: str = "efsm",
         return_atom_feas: bool = False,
         return_crystal_feas: bool = False,
@@ -617,7 +619,7 @@ class CHGNet(nn.Module):
         return result
 
     def as_dict(self):
-        """Return the CHGNet weights and args in a dictionary"""
+        """Return the CHGNet weights and args in a dictionary."""
         out = {"state_dict": self.state_dict(), "model_args": self.model_args}
         return out
 

--- a/chgnet/trainer/__init__.py
+++ b/chgnet/trainer/__init__.py
@@ -1,3 +1,5 @@
-from chgnet.trainer import Trainer
+from __future__ import annotations
+
+from chgnet.trainer.trainer import Trainer
 
 __all__ = ["Trainer"]

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import inspect
 import os.path

--- a/chgnet/utils/__init__.py
+++ b/chgnet/utils/__init__.py
@@ -1,3 +1,5 @@
-from chgnet.utils import AverageMeter, mae, mkdir, read_json, write_json
+from __future__ import annotations
+
+from chgnet.utils.utils import AverageMeter, mae, mkdir, read_json, write_json
 
 __all__ = ["AverageMeter", "mae", "mkdir", "read_json", "write_json"]

--- a/chgnet/utils/utils.py
+++ b/chgnet/utils/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/examples/make_graphs.py
+++ b/examples/make_graphs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import random
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ ignore = [
     "SIM115", # Use context handler for opening files
 ]
 pydocstyle.convention = "google"
+isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["D103"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 """Created on Feb 22 2023
 @author: Bowen Deng.
 """
+from __future__ import annotations
+
 import os
 
 from setuptools import find_packages, setup

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pymatgen.core import Structure
 from pytest import approx
 


### PR DESCRIPTION
Using the side-effect `from __future__ import annotations`, Python backports support for the 3.10 type annotation syntax all the way to 3.7.