### PR TITLE
Add test for `predict_structure()`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include *.py requirements*.txt
-recursive-include chgnet *.py *.json
-recursive-include chgnet/pretrained *

--- a/chgnet/__init__.py
+++ b/chgnet/__init__.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
+from typing import Literal
 
 try:
     __version__ = version(__name__)  # read from setup.py
 except PackageNotFoundError:
     __version__ = "unknown"
+
+TrainTask = Literal["ef", "efs", "efsm"]
+PredTask = Literal["e", "ef", "em", "efs", "efsm"]

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -4,7 +4,6 @@ import functools
 import os
 import random
 import warnings
-from typing import Literal
 
 import numpy as np
 import torch
@@ -12,7 +11,7 @@ from pymatgen.core.structure import Structure
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.sampler import SubsetRandomSampler
 
-from chgnet import utils
+from chgnet import PredTask, TrainTask, utils
 from chgnet.graph import CrystalGraph, CrystalGraphConverter
 
 warnings.filterwarnings("ignore")
@@ -102,7 +101,7 @@ class StructureData(Dataset):
                 return crystal_graph, targets
 
             # Omit structures with isolated atoms. Return another random selected structure
-            except:
+            except Exception:
                 struc = Structure.from_dict(self.structures[graph_id])
                 self.failed_graph_id[graph_id] = struc.composition.formula
                 self.failed_idx.append(idx)
@@ -120,7 +119,7 @@ class CIFData(Dataset):
         self,
         cif_path: str,
         labels: str | dict = "labels.json",
-        targets: Literal["ef", "efs", "efsm"] = "ef",
+        targets: TrainTask = "ef",
         graph_converter: CrystalGraphConverter = None,
         **kwargs,
     ) -> None:
@@ -221,7 +220,7 @@ class GraphData(Dataset):
         self,
         graph_path: str,
         labels: str | dict = "labels.json",
-        targets: str = "efsm",
+        targets: PredTask = "efsm",
         exclude: str | list = None,
         **kwargs,
     ) -> None:
@@ -230,8 +229,7 @@ class GraphData(Dataset):
         Args:
             graph_path (str): path that contain all the graphs, labels.json
             labels (str, dict): the path or dictionary of labels
-            targets (str): the training targets i.e. "ef", "efs", "efsm"
-                Default = "efsm"
+            targets ("ef" | "efs" | "efsm"): The training targets. Default = "efsm"
         """
         self.graph_path = graph_path
         if isinstance(labels, str):
@@ -434,7 +432,7 @@ class StructureJsonData(Dataset):
         self,
         data: str | dict,
         graph_converter: CrystalGraphConverter,
-        targets: Literal["ef", "efs", "efsm"] = "efsm",
+        targets: TrainTask = "efsm",
         **kwargs,
     ) -> None:
         """Initialize the dataset by reading Json files.

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -61,11 +61,15 @@ class StructureData(Dataset):
         self.failed_graph_id = {}
 
     def __len__(self):
+        """Get the number of structures in this dataset."""
         return len(self.keys)
 
     @functools.lru_cache(maxsize=None)  # Cache loaded structures
-    def __getitem__(self, idx) -> (CrystalGraph, dict):
-        """get one item in the dataset.
+    def __getitem__(self, idx) -> tuple[CrystalGraph, dict]:
+        """Get one graph for a structure in this dataset.
+
+        Args:
+            idx (int): Index of the structure
 
         Returns:
             crystal_graph (CrystalGraph): graph of the crystal structure
@@ -319,7 +323,7 @@ class GraphData(Dataset):
         batch_size=32,
         num_workers=0,
         pin_memory=True,
-    ) -> (DataLoader, DataLoader, DataLoader):
+    ) -> tuple[DataLoader, DataLoader, DataLoader]:
         """Partition the GraphData using materials id,
         randomly select the train_keys, val_keys, test_keys by train val test ratio,
         or use pre-defined train_keys, val_keys, and test_keys to create train, val, test loaders.
@@ -422,8 +426,8 @@ class GraphData(Dataset):
 
 
 class StructureJsonData(Dataset):
-    """read structure and targets from a json file
-    this function is used to load MPtrj dataset.
+    """Read structure and targets from a JSON file.
+    This function is used to load MPtrj dataset.
     """
 
     def __init__(
@@ -469,6 +473,7 @@ class StructureJsonData(Dataset):
         self.failed_graph_id = {}
 
     def __len__(self):
+        """Get the number of structures with targets in the dataset."""
         return len(self.keys)
 
     @functools.lru_cache(maxsize=None)  # Cache loaded structures
@@ -509,7 +514,7 @@ class StructureJsonData(Dataset):
                 return crystal_graph, targets
 
             # Omit structures with isolated atoms. Return another random selected structure
-            except:
+            except Exception:
                 structure = Structure.from_dict(self.data[mp_id][graph_id]["structure"])
                 self.failed_graph_id[graph_id] = structure.composition.formula
                 self.failed_idx.append(idx)
@@ -529,7 +534,7 @@ class StructureJsonData(Dataset):
         batch_size=32,
         num_workers=0,
         pin_memory=True,
-    ) -> (DataLoader, DataLoader, DataLoader):
+    ) -> tuple[DataLoader, DataLoader, DataLoader]:
         """Partition the Dataset using materials id,
         randomly select the train_keys, val_keys, test_keys by train val test ratio,
         or use pre-defined train_keys, val_keys, and test_keys to create train, val, test loaders.

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -30,7 +30,7 @@ class StructureData(Dataset):
         stresses: list = None,
         magmoms: list = None,
         graph_converter: CrystalGraphConverter = None,
-    ):
+    ) -> None:
         """Initialize the dataset.
 
         Args:
@@ -123,7 +123,7 @@ class CIFData(Dataset):
         targets: Literal["ef", "efs", "efsm"] = "ef",
         graph_converter: CrystalGraphConverter = None,
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the dataset from a directory containing cifs.
 
         Args:
@@ -224,7 +224,7 @@ class GraphData(Dataset):
         targets: str = "efsm",
         exclude: str | list = None,
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the dataset from a directory containing saved crystal graphs.
 
         Args:
@@ -436,7 +436,7 @@ class StructureJsonData(Dataset):
         graph_converter: CrystalGraphConverter,
         targets: Literal["ef", "efs", "efsm"] = "efsm",
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the dataset by reading Json files.
 
         Args:

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Literal
+from typing import Any, Literal
 
 import torch
 from pymatgen.core.structure import Structure
@@ -59,7 +59,8 @@ class CrystalGraph:
             mp_id (str) or None: Materials Project id of this structure
                 Default = None
             composition: the chemical composition of the compound, used just for better tracking
-                Default = None
+                Default = None.
+
         Returns:
             Crystal Graph.
         """
@@ -81,7 +82,7 @@ class CrystalGraph:
             directed2undirected
         ), f"Error: {graph_id} number of directed index != 2 * number of undirected index!"
 
-    def to(self, device="cpu"):
+    def to(self, device="cpu") -> CrystalGraph:
         return CrystalGraph(
             atomic_number=self.atomic_number.to(device),
             atom_frac_coord=self.atom_frac_coord.to(device),
@@ -98,7 +99,7 @@ class CrystalGraph:
             composition=self.composition,
         )
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "atomic_number": self.atomic_number,
             "atom_frac_coord": self.atom_frac_coord,
@@ -115,7 +116,7 @@ class CrystalGraph:
             "composition": self.composition,
         }
 
-    def save(self, fname=None, save_dir="./"):
+    def save(self, fname: str = None, save_dir: str = "./") -> str:
         if fname is not None:
             save_name = os.path.join(save_dir, fname)
         elif self.graph_id is not None:
@@ -126,15 +127,15 @@ class CrystalGraph:
         return save_name
 
     @classmethod
-    def from_file(cls, file_name):
+    def from_file(cls, file_name) -> CrystalGraph:
         graph = torch.load(file_name)
         return graph
 
     @classmethod
-    def from_dict(cls, dic):
+    def from_dict(cls, dic) -> CrystalGraph:
         return CrystalGraph(**dic)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Details of the graph."""
         return (
             f"Crystal Graph {self.composition} \n"
@@ -145,7 +146,7 @@ class CrystalGraph:
             f"bond_graph={len(self.bond_graph)})"
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
 
@@ -269,7 +270,9 @@ class CrystalGraphConverter(nn.Module):
             bond_graph_cutoff=self.bond_graph_cutoff,
         )
 
-    def get_neighbors(self, structure: Structure):
+    def get_neighbors(
+        self, structure: Structure
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Get neighbor information from pymatgen utility function.
 
         Args:
@@ -283,7 +286,7 @@ class CrystalGraphConverter(nn.Module):
         )
         return center_index, neighbor_index, image, distance
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, float]:
         """Save the args of the graph converter."""
         return {
             "atom_graph_cutoff": self.atom_graph_cutoff,
@@ -291,6 +294,6 @@ class CrystalGraphConverter(nn.Module):
         }
 
     @classmethod
-    def from_dict(cls, dict):
+    def from_dict(cls, dict) -> CrystalGraphConverter:
         """Create converter from dictionary."""
         return CrystalGraphConverter(**dict)

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -31,7 +31,7 @@ class CrystalGraph:
         graph_id: str = None,
         mp_id: str = None,
         composition: str = None,
-    ):
+    ) -> None:
         """Initialize the crystal graph.
         Attention! This data class is not intended to be created manually.
                    Crystal Graph should be returned by a CrystalGraphConverter
@@ -159,7 +159,7 @@ class CrystalGraphConverter(nn.Module):
         atom_graph_cutoff: float = 5,
         bond_graph_cutoff: float = 3,
         verbose: bool = False,
-    ):
+    ) -> None:
         """Initialize the Crystal Graph Converter.
 
         Args:

--- a/chgnet/graph/graph.py
+++ b/chgnet/graph/graph.py
@@ -125,23 +125,25 @@ class Graph:
             # it's the other directed edge of the same undirected edge or it's another
             # totally different undirected edge that has different image and distance
             for undirected_edge in self.undirected_edges[tmp]:
-                if abs(undirected_edge.info["distance"] - distance) < 1e-6:
-                    if len(undirected_edge.info["directed_edge_index"]) == 1:
-                        e = self.directed_edges_list[
-                            undirected_edge.info["directed_edge_index"][0]
+                if (
+                    abs(undirected_edge.info["distance"] - distance) < 1e-6
+                    and len(undirected_edge.info["directed_edge_index"]) == 1
+                ):
+                    e = self.directed_edges_list[
+                        undirected_edge.info["directed_edge_index"][0]
+                    ]
+                    if e == directed_edge:
+                        directed_edge.info["undirected_edge_index"] = e.info[
+                            "undirected_edge_index"
                         ]
-                        if e == directed_edge:
-                            directed_edge.info["undirected_edge_index"] = e.info[
-                                "undirected_edge_index"
-                            ]
-                            self.nodes[center_index].add_neighbor(
-                                neighbor_index, directed_edge
-                            )
-                            self.directed_edges_list.append(directed_edge)
-                            undirected_edge.info["directed_edge_index"].append(
-                                directed_edge_index
-                            )
-                            return
+                        self.nodes[center_index].add_neighbor(
+                            neighbor_index, directed_edge
+                        )
+                        self.directed_edges_list.append(directed_edge)
+                        undirected_edge.info["directed_edge_index"].append(
+                            directed_edge_index
+                        )
+                        return
 
             # no undirected_edge matches to this directed edge
             directed_edge.info["undirected_edge_index"] = len(

--- a/chgnet/graph/graph.py
+++ b/chgnet/graph/graph.py
@@ -6,7 +6,7 @@ from chgnet import utils
 class Node:
     """a node in a graph."""
 
-    def __init__(self, index: int, info: dict = None):
+    def __init__(self, index: int, info: dict = None) -> None:
         self.index = index
         self.info = info
         self.neighbors = {}
@@ -26,7 +26,7 @@ class Node:
 class UndirectedEdge:
     """An edge in a graph."""
 
-    def __init__(self, nodes: list, index: int = None, info: dict = None):
+    def __init__(self, nodes: list, index: int = None, info: dict = None) -> None:
         self.nodes = nodes
         self.index = index
         self.info = info
@@ -46,7 +46,7 @@ class UndirectedEdge:
 class DirectedEdge:
     """An edge in a graph."""
 
-    def __init__(self, nodes: list, index: int, info: dict = None):
+    def __init__(self, nodes: list, index: int, info: dict = None) -> None:
         self.nodes = nodes
         self.index = index
         self.info = info
@@ -84,7 +84,7 @@ class DirectedEdge:
 
 
 class Graph:
-    def __init__(self, nodes: list):
+    def __init__(self, nodes: list) -> None:
         self.nodes = nodes
         self.directed_edges = {}
         self.directed_edges_list = []

--- a/chgnet/model/basis.py
+++ b/chgnet/model/basis.py
@@ -8,7 +8,7 @@ from torch import Tensor, nn
 class Fourier(nn.Module):
     """Fourier Expansion for angle features."""
 
-    def __init__(self, order: int = 5, learnable: bool = False):
+    def __init__(self, order: int = 5, learnable: bool = False) -> None:
         """Initialize the Fourier expansion.
 
         Args:
@@ -50,7 +50,7 @@ class RadialBessel(torch.nn.Module):
         cutoff: float = 5,
         learnable: bool = False,
         smooth_cutoff: int = 5,
-    ):
+    ) -> None:
         """Initialize the SmoothRBF function.
 
         Args:
@@ -110,7 +110,7 @@ class GaussianExpansion(nn.Module):
 
     def __init__(
         self, min: float = 0, max: float = 5, step: float = 0.5, var: float = None
-    ):
+    ) -> None:
         """Gaussian Expansion
         expand a scalar feature to a soft-one-hot feature vector.
 
@@ -148,7 +148,7 @@ class CutoffPolynomial(nn.Module):
     ref: https://github.com/TUM-DAML/gemnet_pytorch/blob/master/gemnet/model/layers/envelope.py.
     """
 
-    def __init__(self, cutoff: float = 5, cutoff_coeff: float = 5):
+    def __init__(self, cutoff: float = 5, cutoff_coeff: float = 5) -> None:
         """Initialize the polynomial cutoff function.
 
         Args:

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -20,7 +20,7 @@ class Composition_model(nn.Module):
         activation: str = "silu",
         is_intensive: bool = True,
         max_num_elements: int = 94,
-    ):
+    ) -> None:
         super().__init__()
         self.is_intensive = is_intensive
         self.max_num_elements = max_num_elements

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -51,7 +51,7 @@ class CHGNetCalculator(Calculator):
         use_device: str | None = None,
         stress_weight: float | None = 1 / 160.21766208,
         **kwargs,
-    ):
+    ) -> None:
         """Provide a CHGNet instance to calculate various atomic properties using ASE.
 
         Args:
@@ -226,7 +226,7 @@ class TrajectoryObserver:
     intermediate structures.
     """
 
-    def __init__(self, atoms: Atoms):
+    def __init__(self, atoms: Atoms) -> None:
         """Create a TrajectoryObserver from an Atoms object.
 
         Args:
@@ -302,7 +302,7 @@ class MolecularDynamics:
         loginterval: int = 1,
         append_trajectory: bool = False,
         use_device: str = None,
-    ):
+    ) -> None:
         """Initialize the MD class.
 
         Args:

--- a/chgnet/model/encoders.py
+++ b/chgnet/model/encoders.py
@@ -9,7 +9,7 @@ from chgnet.model.basis import Fourier, RadialBessel
 class AtomEmbedding(nn.Module):
     """Encode an atom by its atomic number using a learnable embedding layer."""
 
-    def __init__(self, atom_feature_dim: int, max_num_elements: int = 94):
+    def __init__(self, atom_feature_dim: int, max_num_elements: int = 94) -> None:
         """Initialize the Atom featurizer
         Args:
             atom_feature_dim (int): dimension of atomic embedding.
@@ -38,7 +38,7 @@ class BondEncoder(nn.Module):
         num_radial: int = 9,
         cutoff_coeff: int = 5,
         learnable: bool = False,
-    ):
+    ) -> None:
         """Initialize the bond encoder.
 
         Args:
@@ -102,7 +102,7 @@ class BondEncoder(nn.Module):
 class AngleEncoder(nn.Module):
     """Encode an angle given the two bond vectors using Fourier Expansion."""
 
-    def __init__(self, num_angular: int = 9, learnable: bool = True):
+    def __init__(self, num_angular: int = 9, learnable: bool = True) -> None:
         """Initialize the angle encoder.
 
         Args:

--- a/chgnet/model/encoders.py
+++ b/chgnet/model/encoders.py
@@ -69,7 +69,7 @@ class BondEncoder(nn.Module):
         undirected2directed: Tensor,
         image: Tensor,
         lattice: Tensor,
-    ) -> (Tensor, Tensor, Tensor):
+    ) -> tuple[Tensor, Tensor, Tensor]:
         """Compute the pairwise distance between 2 3d coordinates.
 
         Args:

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -48,7 +48,7 @@ class MLP(nn.Module):
         hidden_dim: list[int] | int = (64, 64),
         dropout=0,
         activation="silu",
-    ):
+    ) -> None:
         """Initialize the MLP.
 
         Args:
@@ -105,7 +105,7 @@ class GatedMLP(nn.Module):
         dropout=0,
         activation="silu",
         norm="batch",
-    ):
+    ) -> None:
         """Args:
         input_dim (int): the input dimension
         output_dim (int): the output dimension
@@ -159,7 +159,7 @@ class GatedMLP(nn.Module):
 class ScaledSiLU(torch.nn.Module):
     """Scaled Sigmoid Linear Unit."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.scale_factor = 1 / 0.6
         self._activation = torch.nn.SiLU()

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 import torch
 from torch import Tensor, nn
 
@@ -10,8 +12,7 @@ def aggregate(data: Tensor, owners: Tensor, average=True, num_owner=None) -> Ten
     Args:
         data (Tensor): data tensor to aggregate [n_row, feature_dim]
         owners (Tensor): specify the owner of each row [n_row, 1]
-        average (bool): if True, average the rows,
-                        if False, sum the rows
+        average (bool): if True, average the rows, if False, sum the rows.
             Default = True
         num_owner (int, optional): the number of owners, this is needed if the
             max idx of owner is not presented in owners tensor
@@ -20,21 +21,21 @@ def aggregate(data: Tensor, owners: Tensor, average=True, num_owner=None) -> Ten
     Returns:
         output (Tensor): [num_owner, feature_dim]
     """
-    bincount = torch.bincount(owners)
-    bincount = bincount.where(bincount != 0, bincount.new_ones(1))
+    bin_count = torch.bincount(owners)
+    bin_count = bin_count.where(bin_count != 0, bin_count.new_ones(1))
 
     # If there exist 5 owners, but only the first 4 appear in the owners tensor,
     # we would like the output to have shape [5, fea_dim] with the last row = 0
     # So, we need to optionally add the fifth owner as a row with zero in the output
-    if (num_owner is not None) and (bincount.shape[0] != num_owner):
-        difference = num_owner - bincount.shape[0]
-        bincount = torch.cat([bincount, bincount.new_ones(difference)])
+    if (num_owner is not None) and (bin_count.shape[0] != num_owner):
+        difference = num_owner - bin_count.shape[0]
+        bin_count = torch.cat([bin_count, bin_count.new_ones(difference)])
 
     # make sure this operation is done on the same device of data and owners
-    output = data.new_zeros([bincount.shape[0], data.shape[1]])
+    output = data.new_zeros([bin_count.shape[0], data.shape[1]])
     output = output.index_add_(0, owners, data)
     if average:
-        output = (output.T / bincount).T
+        output = (output.T / bin_count).T
     return output
 
 
@@ -45,7 +46,7 @@ class MLP(nn.Module):
         self,
         input_dim: int = None,
         output_dim: int = 1,
-        hidden_dim: list[int] | int = (64, 64),
+        hidden_dim: int | Sequence[int] = (64, 64),
         dropout=0,
         activation="silu",
     ) -> None:

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -164,11 +164,11 @@ class ScaledSiLU(torch.nn.Module):
         self.scale_factor = 1 / 0.6
         self._activation = torch.nn.SiLU()
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         return self._activation(x) * self.scale_factor
 
 
-def find_activation(name: str):
+def find_activation(name: str) -> nn.Module:
     """Return an activation function using name."""
     try:
         return {
@@ -184,7 +184,7 @@ def find_activation(name: str):
         raise NotImplementedError
 
 
-def find_normalization(name: str, dim: int = None):
+def find_normalization(name: str, dim: int = None) -> nn.Module | None:
     """Return an normalization function using name."""
     if name is None:
         return None

--- a/chgnet/model/layers.py
+++ b/chgnet/model/layers.py
@@ -26,7 +26,7 @@ class AtomConv(nn.Module):
         use_mlp_out: bool = True,
         resnet: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.
         bond_fea_dim (int): The dimensionality of the input bond features.
@@ -140,7 +140,7 @@ class BondConv(nn.Module):
         use_mlp_out: bool = True,
         resnet=True,
         **kwargs,
-    ):
+    ) -> None:
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.
         bond_fea_dim (int): The dimensionality of the input bond features.
@@ -258,7 +258,7 @@ class AngleUpdate(nn.Module):
         norm: str = None,
         resnet: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         """Args:
         atom_fea_dim (int): The dimensionality of the input atom features.
         bond_fea_dim (int): The dimensionality of the input bond features.
@@ -341,7 +341,7 @@ class AngleUpdate(nn.Module):
 class GraphPooling(nn.Module):
     """Pooling the sub-graphs in the batched graph."""
 
-    def __init__(self, average: bool = False):
+    def __init__(self, average: bool = False) -> None:
         """Args:
         average (bool): whether to average the features.
         """
@@ -370,7 +370,7 @@ class GraphAttentionReadOut(nn.Module):
 
     def __init__(
         self, atom_fea_dim: int, num_head: int = 3, hidden_dim: int = 32, average=False
-    ):
+    ) -> None:
         """Initialize the layer.
 
         Args:

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -8,6 +8,7 @@ import torch
 from pymatgen.core import Structure
 from torch import Tensor, nn
 
+from chgnet import PredTask
 from chgnet.graph import CrystalGraph, CrystalGraphConverter
 from chgnet.model.composition_model import Atom_Ref
 from chgnet.model.encoders import AngleEncoder, AtomEmbedding, BondEncoder
@@ -286,7 +287,7 @@ class CHGNet(nn.Module):
     def forward(
         self,
         graphs: Sequence[CrystalGraph],
-        task: str = "e",
+        task: PredTask = "e",
         return_atom_feas: bool = False,
         return_crystal_feas: bool = False,
     ) -> dict:
@@ -476,7 +477,7 @@ class CHGNet(nn.Module):
     def predict_structure(
         self,
         structure: Structure | Sequence[Structure],
-        task: str = "efsm",
+        task: PredTask = "efsm",
         return_atom_feas: bool = False,
         return_crystal_feas: bool = False,
         batch_size: int = 100,
@@ -530,7 +531,7 @@ class CHGNet(nn.Module):
     def predict_graph(
         self,
         graph: CrystalGraph | Sequence[CrystalGraph],
-        task: str = "efsm",
+        task: PredTask = "efsm",
         return_atom_feas: bool = False,
         return_crystal_feas: bool = False,
         batch_size: int = 100,

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -279,9 +279,7 @@ class CHGNet(nn.Module):
             )
 
         print(
-            "CHGNet initialized with",
-            sum(p.numel() for p in self.parameters()),
-            "Parameters",
+            f"CHGNet initialized with {sum(p.numel() for p in self.parameters()):,} parameters"
         )
 
     def forward(
@@ -663,7 +661,7 @@ class BatchedGraph:
         directed2undirected: Tensor,
         atom_positions: Sequence[Tensor],
         strains: Sequence[Tensor],
-        volumes: [Tensor],
+        volumes: Sequence[Tensor],
     ) -> None:
         """Batched crystal graph.
 

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -663,7 +663,7 @@ class BatchedGraph:
         atom_positions: Sequence[Tensor],
         strains: Sequence[Tensor],
         volumes: [Tensor],
-    ):
+    ) -> None:
         """Batched crystal graph.
 
         Args:

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -9,7 +9,7 @@ import time
 
 import numpy as np
 import torch
-from torch import nn
+from torch import Tensor, nn
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     CosineAnnealingWarmRestarts,
@@ -127,12 +127,7 @@ class Trainer:
             scheduler_params = kwargs.pop(
                 "scheduler_params",
                 {
-                    "milestones": [
-                        int(4 * epochs),
-                        int(6 * epochs),
-                        int(8 * epochs),
-                        int(9 * epochs),
-                    ],
+                    "milestones": [4 * epochs, 6 * epochs, 8 * epochs, 9 * epochs],
                     "gamma": 0.3,
                 },
             )
@@ -184,7 +179,7 @@ class Trainer:
 
         self.print_freq = print_freq
         self.training_history = {
-            i: {"train": [], "val": [], "test": []} for i in self.targets
+            key: {"train": [], "val": [], "test": []} for key in self.targets
         }
         self.best_model = None
 
@@ -225,9 +220,9 @@ class Trainer:
 
             # val
             val_mae = self._validate(val_loader)
-            for i in self.targets:
-                self.training_history[i]["train"].append(train_mae[i])
-                self.training_history[i]["val"].append(val_mae[i])
+            for key in self.targets:
+                self.training_history[key]["train"].append(train_mae[key])
+                self.training_history[key]["val"].append(val_mae[key])
 
             if "e" in val_mae and val_mae["e"] != val_mae["e"]:
                 print("Exit due to NaN")
@@ -251,8 +246,8 @@ class Trainer:
                 test_mae = self._validate(
                     test_loader, is_test=True, test_result_save_path=None
                 )
-            for i in self.targets:
-                self.training_history[i]["test"].append(test_mae[i])
+            for key in self.targets:
+                self.training_history[key]["test"].append(test_mae[key])
 
     def _train(self, train_loader: DataLoader, current_epoch: int) -> dict:
         """Train all data for one epoch.
@@ -291,10 +286,10 @@ class Trainer:
             combined_loss = self.criterion(targets, prediction)
 
             losses.update(combined_loss["loss"].data.cpu().item(), len(graphs))
-            for k in self.targets:
-                mae_errors[k].update(
-                    combined_loss[f"{k}_MAE"].cpu().item(),
-                    combined_loss[f"{k}_MAE_size"],
+            for key in self.targets:
+                mae_errors[key].update(
+                    combined_loss[f"{key}_MAE"].cpu().item(),
+                    combined_loss[f"{key}_MAE_size"],
                 )
 
             # compute gradient and do SGD step
@@ -316,20 +311,16 @@ class Trainer:
 
             if (idx + 1) % self.print_freq == 0 or idx == 0:
                 message = (
-                    "Epoch: [{}][{}/{}]\t".format(
-                        current_epoch, idx + 1, len(train_loader)
-                    )
-                    + f"Time ({batch_time.avg:.3f})  "
-                    + f"Data ({data_time.avg:.3f})  "
-                    + "Loss {loss.val:.4f} ({loss.avg:.4f})  ".format(loss=losses)
-                    + "MAEs:  "
+                    f"Epoch: [{current_epoch}][{idx + 1}/{len(train_loader)}]\t"
+                    f"Time ({batch_time.avg:.3f})  Data ({data_time.avg:.3f})  "
+                    f"Loss {losses.val:.4f} ({losses.avg:.4f})  MAEs:  "
                 )
-                for k in self.targets:
-                    message += "{k} {mae_error.val:.3f} ({mae_error.avg:.3f})  ".format(
-                        k=k, mae_error=mae_errors[k]
+                for key in self.targets:
+                    message += (
+                        f"{key} {mae_errors[key].val:.3f} ({mae_errors[key].avg:.3f})  "
                     )
                 print(message)
-        return {k: round(mae_error.avg, 6) for k, mae_error in mae_errors.items()}
+        return {key: round(mae_error.avg, 6) for key, mae_error in mae_errors.items()}
 
     def _validate(
         self,
@@ -532,13 +523,12 @@ class Trainer:
             )
 
     @classmethod
-    def load(cls, path: str):
+    def load(cls, path: str) -> Trainer:
         """Load trainer state_dict."""
         state = torch.load(path, map_location=torch.device("cpu"))
         model = CHGNet.from_dict(state["model"])
         print(
-            "Total Number of loaded Model Params = ",
-            sum(p.numel() for p in model.parameters()),
+            f"Total Number of loaded Model Params = {sum(p.numel() for p in model.parameters()):,}"
         )
         if "model" in state["trainer_args"]:
             del state["trainer_args"]["model"]
@@ -551,15 +541,15 @@ class Trainer:
         return trainer
 
     @staticmethod
-    def move_to(obj, device):
+    def move_to(obj, device) -> Tensor | list[Tensor]:
         """Move object to device."""
         if torch.is_tensor(obj):
             return obj.to(device)
         elif isinstance(obj, list):
             out = []
-            for i in obj:
-                if i is not None:
-                    out.append(i.to(device))
+            for tensor in obj:
+                if tensor is not None:
+                    out.append(tensor.to(device))
                 else:
                     out.append(None)
             return out

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -44,7 +44,7 @@ class Trainer:
         data_seed: int = None,
         use_device: str = None,
         **kwargs,
-    ):
+    ) -> None:
         """Initialize all hyper-parameters for trainer.
 
         Args:
@@ -580,7 +580,7 @@ class CombinedLoss(nn.Module):
         stress_loss_ratio: float = 0.1,
         mag_loss_ratio: float = 0.1,
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the combined loss.
 
         Args:

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -18,6 +18,7 @@ from torch.optim.lr_scheduler import (
 )
 from torch.utils.data import DataLoader
 
+from chgnet import TrainTask
 from chgnet.model.model import CHGNet
 from chgnet.utils import AverageMeter, mae, mkdir, write_json
 
@@ -28,7 +29,7 @@ class Trainer:
     def __init__(
         self,
         model: nn.Module = None,
-        targets: str = "ef",
+        targets: TrainTask = "ef",
         energy_loss_ratio: float = 1,
         force_loss_ratio: float = 1,
         stress_loss_ratio: float = 0.1,
@@ -49,8 +50,7 @@ class Trainer:
 
         Args:
             model (nn.Module): a CHGNet model
-            targets (str): the training targets i.e. "ef", "efs", "efsm"
-                Default = "ef"
+            targets ("ef" | "efs" | "efsm"): The training targets. Default = "ef"
             energy_loss_ratio (float): energy loss ratio in loss function
                 Default = 1
             force_loss_ratio (float): force loss ratio in loss function

--- a/chgnet/utils/utils.py
+++ b/chgnet/utils/utils.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 
 class AverageMeter:
@@ -112,18 +116,27 @@ def write_json(d, fjson):
 
 
 def solve_charge_by_mag(
-    structure,
-    default_ox={"Li": 1, "O": -2},
-    ox_ranges={
-        "Mn": {(0.5, 1.5): 2, (1.5, 2.5): 3, (2.5, 3.5): 4, (3.5, 4.2): 3, (4.2, 5): 2}
-    },
+    structure: Structure,
+    default_ox: dict[str, float] = None,
+    ox_ranges: dict[str, dict[tuple[float, float], int]] = None,
 ):
-    """Args:
-    structure: input pymatgen structure
-    ox_ranges: user defined range to convert magmoms into formal valence.
+    """Solve oxidation states by magmom.
+
+    Args:
+        structure: input pymatgen structure
+        default_ox (dict[str, float]): default oxidation state for elements.
+            Default = {"Li": 1, "O": -2}
+        ox_ranges (dict[str, dict[tuple[float, float], int]]): user defined range to
+            convert magmoms into formal valence. Default = {
+                "Mn": {(0.5, 1.5): 2, (1.5, 2.5): 3, (2.5, 3.5): 4, (3.5, 4.2): 3, (4.2, 5): 2}
+            }
     """
     ox_list = []
     solved_ox = True
+    default_ox = default_ox or {"Li": 1, "O": -2}
+    ox_ranges = ox_ranges or {
+        "Mn": {(0.5, 1.5): 2, (1.5, 2.5): 3, (2.5, 3.5): 4, (3.5, 4.2): 3, (4.2, 5): 2}
+    }
 
     if "final_magmom" in structure.site_properties:
         mag_key = "final_magmom"

--- a/chgnet/utils/utils.py
+++ b/chgnet/utils/utils.py
@@ -9,7 +9,7 @@ import torch
 class AverageMeter:
     """Computes and stores the average and current value."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset()
 
     def reset(self):
@@ -29,7 +29,7 @@ class AverageMeter:
 class MeanNormalizer:
     """Normalize a Tensor and restore it later."""
 
-    def __init__(self, tensor):
+    def __init__(self, tensor) -> None:
         """Tensor is taken as a sample to calculate the mean and std."""
         self.mean = torch.mean(tensor)
         self.std = torch.std(tensor)
@@ -51,7 +51,7 @@ class MeanNormalizer:
 class BaseNormalizer:
     """Base normalizer to normalize target scalar."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.mean = 1
         self.std = 1
 

--- a/examples/make_graphs.py
+++ b/examples/make_graphs.py
@@ -20,14 +20,6 @@ random.seed(100)
 # This is extremely useful if you plan to do hyper-parameter sweeping i.e. learning rate
 
 
-def main():
-    data_path = ""
-    graph_dir = ""
-    converter = CrystalGraphConverter(atom_graph_cutoff=5, bond_graph_cutoff=3)
-    data = StructureJsonData(data_path, graph_converter=converter)
-    make_graphs(data, graph_dir)
-
-
 def make_graphs(
     data: StructureJsonData,
     graph_dir: str,
@@ -79,7 +71,7 @@ def make_one_graph(mp_id: str, graph_id: str, data, graph_dir) -> dict | bool:
 
 def make_partition(
     data, graph_dir, train_ratio=0.8, val_ratio=0.1, partition_with_frame=False
-):
+) -> None:
     """Make a train val test partition."""
     random.seed(42)
     if partition_with_frame is False:
@@ -102,4 +94,9 @@ def make_partition(
 
 
 if __name__ == "__main__":
-    main()
+    data_path = ""
+    graph_dir = ""
+
+    converter = CrystalGraphConverter(atom_graph_cutoff=5, bond_graph_cutoff=3)
+    data = StructureJsonData(data_path, graph_converter=converter)
+    make_graphs(data, graph_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,16 @@ build-backend = "setuptools.build_meta"
 name = "chgnet"
 version = "0.0.1"
 description = "Pretrained Neural Network Potential for Charge-informed Molecular Dynamics"
-authors = [
-    {name = "Bowen Deng", email = "bowendeng@berkeley.edu"}
-]
+authors = [{ name = "Bowen Deng", email = "bowendeng@berkeley.edu" }]
 requires-python = ">=3.8"
 readme = "README.md"
-license = {text = "MIT"}
+license = { text = "MIT" }
 dependencies = [
-        "numpy~=1.21.6",
-        "torch~=1.11.0",
-        "pymatgen~=2022.4.19",
-        "ase==3.22.0",
-    ]
+    "numpy~=1.21.6",
+    "torch~=1.11.0",
+    "pymatgen~=2022.4.19",
+    "ase==3.22.0",
+]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]
@@ -50,11 +48,12 @@ select = [
     "YTT", # flake8-2020
 ]
 ignore = [
-    "D100",   # Missing docstring in public module
-    "D104",   # Missing docstring in public package
-    "D205",   # 1 blank line required between summary line and description
-    "SIM105", # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
-    "SIM115", # Use context handler for opening files
+    "D100",    # Missing docstring in public module
+    "D104",    # Missing docstring in public package
+    "D205",    # 1 blank line required between summary line and description
+    "PLW2901", # Outer for loop variable overwritten by inner assignment target
+    "SIM105",  # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
+    "SIM115",  # Use context handler for opening files
 ]
 pydocstyle.convention = "google"
 isort.required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ test = ["pytest", "pytest-cov"]
 [project.urls]
 Source = "https://github.com/CederGroupHub/chgnet"
 
-[tool.setuptools]
-packages = ["chgnet"]
+[tool.setuptools.packages]
+find = { include = ["chgnet*"], exclude = ["tests*"] }
 
 [tool.setuptools.package-data]
+"chgnet" = ["*.json"]
 "chgnet.pretrained" = ["*.tar"]
 
 [tool.ruff]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+import pytest
 from pymatgen.core import Structure
 from pytest import mark
 
@@ -25,7 +27,7 @@ def test_model(
     num_angular: int,
     n_conv: int,
     composition_model: str,
-):
+) -> None:
     model = CHGNet(
         atom_fea_dim=atom_fea_dim,
         bond_fea_dim=bond_fea_dim,
@@ -39,3 +41,26 @@ def test_model(
     assert list(out) == ["atoms_per_graph", "e"]
     assert out["atoms_per_graph"].shape == (1,)
     assert out["e"] < 0
+
+
+def test_predict_structure() -> None:
+    model = CHGNet.load()
+    out = model.predict_structure(structure)
+
+    assert sorted(out) == ["e", "f", "m", "s"]
+    assert out["e"] == pytest.approx(-7.37159, abs=1e-4)
+    assert len(out["f"]) == len(structure)
+    assert len(out["m"]) == len(structure)
+    assert out["m"] == pytest.approx(
+        [0.00521, 0.00521, 3.85728, 3.85729, 0.02538, 0.03706, 0.03706, 0.02538],
+        abs=1e-4,
+    )
+    assert len(out["s"]) == 3
+    stress = np.array(
+        [
+            [3.3677614e-01, -1.9665707e-07, -5.6416429e-06],
+            [4.9939729e-07, 2.4675032e-01, 1.8549043e-05],
+            [-4.0414070e-06, 1.9096897e-05, 4.0323928e-02],
+        ]
+    )
+    assert out["s"] == pytest.approx(stress, abs=1e-4)


### PR DESCRIPTION
Plus a bunch more type annotations and type aliases

```py
TrainTask = Literal["ef", "efs", "efsm"]
PredTask = Literal["e", "ef", "em", "efs", "efsm"]
```

I think it would be good to add a `tests/test_trainer.py` module next since that's another essential part of the API that's currently untested.