### PR TITLE
Fix markdown formatting in `examples/fine_tuning.ipynb`

### DIFF
--- a/examples/fine_tuning.ipynb
+++ b/examples/fine_tuning.ipynb
@@ -46,11 +46,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "16eeae1e",
    "metadata": {},
    "source": [
-    "## 1. Prepare Training Data"
+    "## 1. Prepare Training Data\n"
    ]
   },
   {
@@ -73,11 +74,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9ec2524a",
    "metadata": {},
    "source": [
-    "### We create a dummy fine-tuning dataset by using CHGNet prediction with some random noise. For your purpose on fine-tuning to specific chemical system or AIMD data, please modify the block below"
+    "We create a dummy fine-tuning dataset by using CHGNet prediction with some random noise. For your purpose on fine-tuning to specific chemical system or AIMD data, please modify the block below\n"
    ]
   },
   {
@@ -108,19 +110,21 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "052536e6",
    "metadata": {},
    "source": [
-    "### Note that the magmom output from CHGNet is in unit of GPa, here the -10 unit conversion modifies it to be kbar in VASP raw unit. We do this since by default, StructureData dataset class takes in VASP units."
+    "Note that the magmom output from CHGNet is in unit of GPa, here the -10 unit conversion modifies it to be kbar in VASP raw unit. We do this since by default, StructureData dataset class takes in VASP units.\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aea8393e",
    "metadata": {},
    "source": [
-    "## 2. Define DataSet"
+    "## 2. Define DataSet\n"
    ]
   },
   {
@@ -153,27 +157,23 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d1dc5ad3",
    "metadata": {},
    "source": [
-    "### Here the batch_size is defined to be 8 for small gpu-memory. If > 10 GB memory is available, we highly recommend increase the batch_size for better speed."
+    "Here the batch_size is defined to be 8 for small gpu-memory. If > 10 GB memory is available, we highly recommend increase the batch_size for better speed.\n",
+    "\n",
+    "If you have so many structures (which is highly typical from AIMD), it's ineffecient to put them all at once into the python list as it's probably impossible for memory issue. In this case we highly recommend you to pre-convert all the structures into graphs and save them using examples/make_graphs.py. And later you can directly train CHGNet by loading the graphs from hard-drive instead of memory using the GraphData class defined in data/dataset.py\n"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "e6437ec3",
-   "metadata": {},
-   "source": [
-    "### If you have so many structures (which is highly typical from AIMD), it's ineffecient to put them all at once into the python list as it's probably impossible for memory issue. In this case we highly recommend you to pre-convert all the structures into graphs and save them using examples/make_graphs.py. And later you can directly train CHGNet by loading the graphs from hard-drive instead of memory using the GraphData class defined in data/dataset.py "
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "99445e44",
    "metadata": {},
    "source": [
-    "## 3. Define model and trainer"
+    "## 3. Define model and trainer\n"
    ]
   },
   {
@@ -190,11 +190,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e3afbc75",
    "metadata": {},
    "source": [
-    "### It's optional to freezing the weights inside some layers. This is a common technique to retain the learned knwoledge during fine-tuning in large pretrained neural networks."
+    "It's optional to freeze the weights inside some layers. This is a common technique to retain the learned knowledge during fine-tuning in large pretrained neural networks.\n"
    ]
   },
   {
@@ -241,11 +242,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6f47fca4",
    "metadata": {},
    "source": [
-    "## 4. Start training"
+    "## 4. Start training\n"
    ]
   },
   {
@@ -259,11 +261,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "169de30e",
    "metadata": {},
    "source": [
-    "### after training, the trained model can be found in the directory of today's date. Or it can be accessed by:"
+    "After training, the trained model can be found in the directory of today's date. Or it can be accessed by:\n"
    ]
   },
   {
@@ -278,33 +281,29 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "abcc09b4",
    "metadata": {},
    "source": [
-    "# Extras 1: GGA / GGA+U compatibility"
+    "## Extras 1: GGA / GGA+U compatibility\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0a977284",
    "metadata": {},
    "source": [
-    "## Q: Why and When do you care about this?\n",
+    "### Q: Why and when do you care about this?\n",
     "\n",
-    "### When: If you want to fine-tune the pretrained CHGNet with your own GGA+U VASP calculations, and you want to keep your VASP energy compatible to the pretrained dataset. In case your dataset is so large that the pretrained knowledge does not matter to you, you can ignore this."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4bb08d3e",
-   "metadata": {},
-   "source": [
-    "### Why: CHGNet is traine on both GGA and GGA + U calculations from Materials Project. And there has been developed methods in solving the compatibility between GGA and GGA+U calculations which makes the energies universally applicable for cross-chemistry comparison and phase-diagram constructions. Please refer to:\n",
+    "**When**: If you want to fine-tune the pretrained CHGNet with your own GGA+U VASP calculations, and you want to keep your VASP energy compatible to the pretrained dataset. In case your dataset is so large that the pretrained knowledge does not matter to you, you can ignore this.\n",
     "\n",
-    "### https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.045115\n",
+    "**Why**: CHGNet is trained on both GGA and GGA+U calculations from Materials Project. And there has been developed methods in solving the compatibility between GGA and GGA+U calculations which makes the energies universally applicable for cross-chemistry comparison and phase-diagram constructions. Please refer to:\n",
     "\n",
-    "### Below I will show an example to apply the compatibility"
+    "https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.045115\n",
+    "\n",
+    "Below we show an example to apply the compatibility.\n"
    ]
   },
   {
@@ -314,21 +313,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Imagine this is VASP raw energy\n",
+    "# Imagine this is the VASP raw energy\n",
     "chgnet = CHGNet.load()\n",
     "VASP_raw_energy = chgnet.predict_structure(lmo)[\"e\"] * len(lmo)\n",
     "print(f\"The raw total energy from VASP of LMO is: {VASP_raw_energy}\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cce51fa9",
    "metadata": {},
    "source": [
-    "### You can look for the energy correction applied to each element in :\n",
-    "### https://github.com/materialsproject/pymatgen/blob/v2023.2.28/pymatgen/entries/MP2020Compatibility.yaml\n",
+    "You can look for the energy correction applied to each element in :\n",
     "\n",
-    "### Here LiMnO2 applies to both Mn in transition metal oxides correction and oxide correction."
+    "https://github.com/materialsproject/pymatgen/blob/v2023.2.28/pymatgen/entries/MP2020Compatibility.yaml\n",
+    "\n",
+    "Here LiMnO2 applies to both Mn in transition metal oxides correction and oxide correction.\n"
    ]
   },
   {
@@ -352,33 +353,36 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "deeb3814",
    "metadata": {},
    "source": [
-    "### now use this corrected energy as labels to tune the CHGNet, you're good to go!"
+    "Now use this corrected energy as labels to tune CHGNet, you're good to go!\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5c36fe61",
    "metadata": {},
    "source": [
-    "# Extras 2: AtomRef"
+    "## Extras 2: AtomRef\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "dbb93bc0",
    "metadata": {},
    "source": [
-    "### If you want to fine tune CHGNet to DFT labels that are even more incompatible with Materials Project, like r2SCAN functional, or other DFTs like Gaussian or QE. More trick has to be done to withhold the most amount of information learned during pretraining.\n",
+    "If you want to fine tune CHGNet to DFT labels that are even more incompatible with Materials Project, like r2SCAN functional, or other DFTs like Gaussian or QE. More trick has to be done to withhold the most amount of information learned during pretraining.\n",
     "\n",
-    "### For example, formation energy can be a well-compatible property across different functionals. In CHGNet, we use a Atom_Ref operation, which is a formation-energy-like calculation for per-element contribution to the total energy.\n",
+    "For example, formation energy can be a well-compatible property across different functionals. In CHGNet, we use a Atom_Ref operation, which is a formation-energy-like calculation for per-element contribution to the total energy.\n",
     "\n",
-    "### When fine-tuning to other functionals that might have large discrepancy in elemental energies. We recommend you to refit the AtomRef. So that the finetuning on the graph layers can be focused on energy contribution from atom-atom interaction instead of meanigless atom reference energies.\n",
+    "When fine-tuning to other functionals that might have large discrepancy in elemental energies. We recommend you to refit the AtomRef. So that the finetuning on the graph layers can be focused on energy contribution from atom-atom interaction instead of meaningless atom reference energies.\n",
     "\n",
-    "### Below I will show an example to refit the AtomRef layer:"
+    "Below I will show an example to refit the AtomRef layer:\n"
    ]
   },
   {
@@ -389,8 +393,8 @@
    "outputs": [],
    "source": [
     "print(\"The pretrained Atom_Ref (per atom reference energy):\")\n",
-    "for i in chgnet.composition_model.parameters():\n",
-    "    print(i)"
+    "for param in chgnet.composition_model.parameters():\n",
+    "    print(param)"
    ]
   },
   {
@@ -436,8 +440,8 @@
     "print(\"We initialize another identical AtomRef layers\")\n",
     "new_AtomRef = AtomRef(is_intensive=True)\n",
     "new_AtomRef.initialize_from_MPtrj()\n",
-    "for i in new_AtomRef.parameters():\n",
-    "    print(i[:, :3])"
+    "for param in new_AtomRef.parameters():\n",
+    "    print(param[:, :3])"
    ]
   },
   {


### PR DESCRIPTION
I noticed `examples/fine_tuning.ipynb` uses headings for block text which makes the notebook hard to read on GitHub:

![Screenshot 2023-04-18 at 13 34 02](https://user-images.githubusercontent.com/30958850/232899139-47b930bf-71f0-4223-8660-46b1a69b1540.png)

This PR makes the text smaller and fixes some typos.