### PR TITLE
coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,11 @@ name: Tests
 on:
   push:
     branches: [main]
-  pull_request:
+  # Needed to allow secrets access to forked PRs, consider breaking up workflow
+  # by running tests on pull_request, saving artifacts, and then running another
+  # workflow on pull_request_target to allow only minimal access to secrets
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
     branches: [main]
 
 jobs:
@@ -33,7 +37,7 @@ jobs:
         run: pytest --capture=no --cov --cov-report=xml .
 
       - name: codacy-coverage-reporter
-        if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest'
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: pytest --capture=no --cov --cov-report=xml .
 
       - name: codacy-coverage-reporter
-        if: ${{ matrix.os == ubuntu-latest }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,10 @@ jobs:
           pip install -e .[test]
 
       - name: Run Tests
-        run: pytest --capture=no --cov .
+        run: pytest --capture=no --cov --cov-report=xml .
+
+      - name: codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+            project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+            coverage-reports: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
         run: pytest --capture=no --cov --cov-report=xml .
 
       - name: codacy-coverage-reporter
-        if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
-            project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-            coverage-reports: coverage.xml
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         run: pytest --capture=no --cov --cov-report=xml .
 
       - name: codacy-coverage-reporter
+        if: ${{ matrix.os == ubuntu-latest }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: pytest --capture=no --cov --cov-report=xml .
 
       - name: codacy-coverage-reporter
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,4 +71,4 @@ isort.required-imports = ["from __future__ import annotations"]
 source = ["chgnet"]
 
 [tool.coverage.report]
-omit = ["tests/*", ]
+omit = ["tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,9 @@ isort.required-imports = ["from __future__ import annotations"]
 [tool.ruff.per-file-ignores]
 "tests/*" = ["D103"]
 "examples/*" = ["E402"] # E402 Module level import not at top of file
+
+[tool.coverage.run]
+source = ["chgnet"]
+
+[tool.coverage.report]
+omit = ["tests/*", ]


### PR DESCRIPTION
Setup coverage reporting with Codacy.

Following #25 we can now add a coverage badge like this:
[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/33b610deea524c73a5f233721c27d8b4)](https://app.codacy.com/gh/lbluque/chgnet/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)

And codacy allows to set gates for maximum coverage diffs allowed in PRs, which is not the same as the coveralls comments that @janosh  referred to in #25 , but serves the purpose, and since we already have a few CederGroup repos on codacy that made the setup for this repo quite easy. 
