### PR TITLE
Use PyPI trusted publishing in CI `release` job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,16 +49,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     if: github.event_name == 'release' && needs.tests.result == 'success'
+    permissions:
+      # For PyPI trusted publishing
+      id-token: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Build and upload dist
+      - name: Build dist
         run: |
-          pip install build twine
+          pip install build
           python -m build
-          twine check dist/* --strict
-          twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*.tar.gz
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.269
+    rev: v0.0.272
     hooks:
       - id: ruff
         args: [--fix]

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -44,8 +44,8 @@ class MLP(nn.Module):
 
     def __init__(
         self,
-        input_dim: int | None = None,
-        output_dim: int | None = 1,
+        input_dim: int,
+        output_dim: int = 1,
         hidden_dim: int | Sequence[int] | None = (64, 64),
         dropout: float = 0,
         activation: str = "silu",
@@ -73,7 +73,7 @@ class MLP(nn.Module):
                 nn.Dropout(dropout),
                 nn.Linear(hidden_dim, output_dim),
             ]
-        else:  # type(hidden_dim) == list:
+        elif isinstance(hidden_dim, Sequence):
             layers = [nn.Linear(input_dim, hidden_dim[0]), find_activation(activation)]
             if len(hidden_dim) != 1:
                 for h_in, h_out in zip(hidden_dim[0:-1], hidden_dim[1:]):
@@ -81,6 +81,10 @@ class MLP(nn.Module):
                     layers.append(find_activation(activation))
             layers.append(nn.Dropout(dropout))
             layers.append(nn.Linear(hidden_dim[-1], output_dim))
+        else:
+            raise TypeError(
+                f"{hidden_dim=} must be an integer, a list of integers, or None."
+            )
         self.layers = nn.Sequential(*layers)
 
     def forward(self, X: Tensor) -> Tensor:
@@ -102,8 +106,8 @@ class GatedMLP(nn.Module):
 
     def __init__(
         self,
-        input_dim: int | None = None,
-        output_dim: int | None = None,
+        input_dim: int,
+        output_dim: int,
         hidden_dim: int | list[int] | None = None,
         dropout=0,
         activation="silu",


### PR DESCRIPTION
[PyPI's new trusted publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers) has 1st party integration with GitHub Actions. Makes it safer and easier to setup automated releases.

I hope this works, haven't tested yet. Maybe a good idea to make a release for #34.

Related PR: https://github.com/materialsproject/pymatgen/pull/3055