### PR TITLE
FIXED MEMORY LEAK in fast graph converter. Also cleaned up unneeded code.

### DIFF
--- a/chgnet/graph/cygraph.pyx
+++ b/chgnet/graph/cygraph.pyx
@@ -62,9 +62,9 @@ cdef extern from 'fast_converter_libraries/create_graph.c':
     LongToDirectedEdgeList** get_neighbors(Node* node)
 
 def make_graph(
-        const long[::1] center_index, 
+        const long[::1] center_index,
         const long n_e,
-        const long[::1] neighbor_index, 
+        const long[::1] neighbor_index,
         const long[:, ::1] image,
         const double[::1] distance,
         const long num_atoms
@@ -166,4 +166,3 @@ def make_graph(
     free(returned)
 
     return py_nodes, py_directed_edges_list, py_undirected_edges_list, py_undirected_edges
-

--- a/chgnet/graph/cygraph.pyx
+++ b/chgnet/graph/cygraph.pyx
@@ -8,10 +8,7 @@
 # distutils: language = c
 
 import chgnet.chgnet.graph
-from cython.operator import dereference
 import numpy as np
-from libc cimport time
-from libc.stdio cimport printf
 from libc.stdlib cimport free
 
 cdef extern from 'fast_converter_libraries/create_graph.c':
@@ -89,31 +86,31 @@ def make_graph(
     cdef DirectedEdge* this_DE
 
     # Handling nodes + directed edges
-    for i in range(returned[0].num_nodes):
-        this_node = dereference(returned).nodes[i]
-        this_py_node = chg_Node(index=i)
+    for idx in range(returned[0].num_nodes):
+        this_node = returned[0].nodes[idx]
+        this_py_node = chg_Node(index=idx)
         this_py_node.neighbors = {}
 
         node_neighbors = get_neighbors(&this_node)
 
         # Iterate through all neighbors and populate our py_node.neighbors dict
         for j in range(this_node.num_neighbors):
-            this_entry = dereference(node_neighbors[j])
+            this_entry = node_neighbors[j][0]
             directed_edges = []
 
             for k in range(this_entry.num_directed_edges_in_group):
                 this_DE = this_entry.directed_edges_list[k]
                 directed_edges.append(this_DE[0].index)
-            
+
             this_py_node.neighbors[this_entry.key] = directed_edges
-        
+
         py_nodes.append(this_py_node)
 
     # Handling directed edges
     py_directed_edges_list = []
 
-    for i in range(returned[0].num_directed_edges):
-        this_DE = returned[0].directed_edges_list[i]
+    for idx in range(returned[0].num_directed_edges):
+        this_DE = returned[0].directed_edges_list[idx]
         py_DE = chg_DirectedEdge(nodes = [this_DE[0].nodes.center, this_DE[0].nodes.neighbor], index=this_DE[0].index, info = {"distance": this_DE[0].distance, "image": image_np[this_DE[0].index], "undirected_edge_index": this_DE[0].undirected_edge_index})
 
         py_directed_edges_list.append(py_DE)
@@ -123,8 +120,8 @@ def make_graph(
     py_undirected_edges_list = []
     cdef UndirectedEdge* UDE
 
-    for i in range(returned[0].num_undirected_edges):
-        UDE = returned[0].undirected_edges_list[i]
+    for idx in range(returned[0].num_undirected_edges):
+        UDE = returned[0].undirected_edges_list[idx]
         py_undirected_edge = chg_UndirectedEdge([UDE[0].nodes.center, UDE[0].nodes.neighbor], index = UDE[0].index, info =  {"distance": UDE[0].distance, "directed_edge_index": []})
 
         for j in range(UDE[0].num_directed_edges):

--- a/chgnet/graph/cygraph.pyx
+++ b/chgnet/graph/cygraph.pyx
@@ -148,12 +148,12 @@ def make_graph(
 
 
     # Free everything unneeded
-    for i in range(returned[0].num_directed_edges):
-        free(returned[0].directed_edges_list[i])
+    for idx in range(returned[0].num_directed_edges):
+        free(returned[0].directed_edges_list[idx])
 
-    for i in range(returned[0].num_undirected_edges):
-        free(returned[0].undirected_edges_list[i].directed_edge_indices)
-        free(returned[0].undirected_edges_list[i])
+    for idx in range(returned[0].num_undirected_edges):
+        free(returned[0].undirected_edges_list[idx].directed_edge_indices)
+        free(returned[0].undirected_edges_list[idx])
 
 
     # Free node LongToDirectedEdgeList

--- a/chgnet/graph/cygraph.pyx
+++ b/chgnet/graph/cygraph.pyx
@@ -3,7 +3,7 @@
 # cython: nonecheck=False
 # cython: boundscheck=False
 # cython: wraparound=False
-# cython: cdivision=False
+# cython: cdivision=True
 # cython: profile=False
 # distutils: language = c
 

--- a/chgnet/graph/cygraph.pyx
+++ b/chgnet/graph/cygraph.pyx
@@ -7,7 +7,7 @@
 # cython: profile=False
 # distutils: language = c
 
-import chgnet.chgnet.graph
+import chgnet.graph.graph
 import numpy as np
 from libc.stdlib cimport free
 

--- a/chgnet/graph/fast_converter_libraries/create_graph.c
+++ b/chgnet/graph/fast_converter_libraries/create_graph.c
@@ -6,10 +6,9 @@ typedef struct _DirectedEdge DirectedEdge;
 typedef struct _Node Node;
 typedef struct _NodeIndexPair NodeIndexPair;
 typedef struct _LongToDirectedEdgeList LongToDirectedEdgeList;
-typedef struct _ReturnElems ReturnElems;
 typedef struct _ReturnElems2 ReturnElems2;
 
-// NOTE: This code was mainly written to replicate the original add_edges method
+// NOTE: This code was mainly written to replicate the original add_edges method 
 // in the graph class in chgnet.graph.graph such that anyone familiar with that code should be able to pick up this
 // code pretty easily.
 
@@ -56,23 +55,6 @@ typedef struct _LongToDirectedEdgeList {
     UT_hash_handle hh;
 } LongToDirectedEdgeList;
 
-typedef struct _ReturnElems {
-    long num_nodes;
-    long* node_index_unraveled;
-    long* node_neighbor_index_unraveled;
-    long* node_directed_edge_index_unraveled;
-
-    long num_undirected_edges;
-    long* undirected_center_index_unraveled;
-    long* undirected_neighbor_index_unraveled;
-    long* undirected_index_unraveled;
-    long* undirected_directed_edge_indices_unraveled;
-    double* undirected_distances_unraveled;
-
-    long num_directed_edges;
-    long* directed_undirected_edge_index_unraveled;
-} ReturnElems;
-
 
 typedef struct _ReturnElems2 {
     long num_nodes;
@@ -81,7 +63,6 @@ typedef struct _ReturnElems2 {
     Node* nodes;
     UndirectedEdge** undirected_edges_list;
     DirectedEdge** directed_edges_list;
-    StructToUndirectedEdgeList* undirected_edges;
 } ReturnElems2;
 
 bool find_in_undirected(NodeIndexPair* tmp, StructToUndirectedEdgeList** undirected_edges, StructToUndirectedEdgeList** found_entry);
@@ -94,7 +75,8 @@ void add_neighbors_to_node(Node* node, long neighbor_index, DirectedEdge* direct
 void print_neighbors(Node* node);
 void append_to_directed_edge_indices(UndirectedEdge* undirected_edge, long directed_edge_index);
 bool is_reversed_directed_edge(DirectedEdge* directed_edge1, DirectedEdge* directed_edge2);
-ReturnElems* get_raw_data(Node* nodes, long num_nodes, long num_undirected_edges, long num_directed_edges, UndirectedEdge** undirected_edges_list, DirectedEdge** directed_edges_list);
+void free_undirected_edges(StructToUndirectedEdgeList** undirected_edges);
+void free_LongToDirectedEdgeList_in_nodes(Node* nodes, long num_nodes);
 
 
 Node* create_nodes(long num_nodes) {
@@ -135,7 +117,7 @@ ReturnElems2* create_graph(
     StructToUndirectedEdgeList* undirected_edges = NULL;
 
     // Pointer to beginning of list of UndirectedEdges corresponding to tmp of current iteration
-    StructToUndirectedEdgeList* corr_undirected_edges_item = NULL;
+    StructToUndirectedEdgeList* corr_undirected_edges_item = NULL; 
 
     // Pointer to NodeIndexPair storing tmp
     NodeIndexPair* tmp = malloc(sizeof(NodeIndexPair));
@@ -144,17 +126,18 @@ ReturnElems2* create_graph(
     bool found = false;
 
     // Flag used to show if we've already processed the current undirected edge
-    bool processed_edge = false;
+    bool processed_edge = false; 
 
     // Pointer used to store the previously added directed edge between two nodes
     DirectedEdge* added_DE;
+    DirectedEdge* this_directed_edge;
 
     // Add all edges to graph information
     for (long i = 0; i < num_edges; i++) {
         // Haven't processed the edge yet
         processed_edge = false;
         // Create the current directed edge -------------------
-        DirectedEdge* this_directed_edge = calloc(1, sizeof(DirectedEdge));
+        this_directed_edge = calloc(1, sizeof(DirectedEdge));
         this_directed_edge->nodes.center = center_indices[i];
         this_directed_edge->nodes.neighbor = neighbor_indices[i];
         this_directed_edge->distance = distances[i];
@@ -172,11 +155,7 @@ ReturnElems2* create_graph(
 
         if (!found) {
             // Never seen this edge combination before
-            // printf("C: new edge combo: %lu and %lu. Dist: %.15lf. Img: [%ld, %ld, %ld]\n", tmp->center, tmp->neighbor, distances[i], *(this_directed_edge->image), *(this_directed_edge->image + 1), *(this_directed_edge->image + 2));
-
             this_directed_edge->undirected_edge_index = num_undirected_edges;
-
-            //TODO: be careful about double-freeing later. we're re-using a lot of memory space
 
             // Create new undirected edge
             UndirectedEdge* this_undirected_edge = malloc(sizeof(UndirectedEdge));
@@ -187,9 +166,9 @@ ReturnElems2* create_graph(
             create_new_undirected_edges_entry(&undirected_edges, tmp, this_undirected_edge);
             append_to_undirected_edges_list(undirected_edges_list, this_undirected_edge, &num_undirected_edges);
             add_neighbors_to_node(&nodes[center_indices[i]], neighbor_indices[i], this_directed_edge);
-            append_to_directed_edges_list(directed_edges_list, this_directed_edge, &num_directed_edges);
+            append_to_directed_edges_list(directed_edges_list, this_directed_edge, &num_directed_edges);    
         } else {
-            // This pair of nodes has been added before. We have to check if it's the other directed edge (but pointed in
+            // This pair of nodes has been added before. We have to check if it's the other directed edge (but pointed in 
             // the different direction) OR it's another totally different undirected edge that has different image and distance
 
             // if found is true, then corr_undirected_edges_item points to self.undirected_edges[tmp]
@@ -224,125 +203,49 @@ ReturnElems2* create_graph(
         }
     }
 
-
-    // ReturnElems* returned;
-    // returned = get_raw_data(nodes, num_atoms, num_undirected_edges, num_directed_edges, undirected_edges_list, directed_edges_list);
-
-    // printf("From returned struct: %lu\n", returned->num_directed_edges);
-    // return returned;
-
     ReturnElems2* returned2 = malloc(sizeof(ReturnElems2));
     returned2->num_nodes = num_atoms;
     returned2->num_undirected_edges = num_undirected_edges;
     returned2->num_directed_edges = num_directed_edges;
-
+    
     returned2->nodes = nodes;
     returned2->directed_edges_list = directed_edges_list;
     returned2->undirected_edges_list = undirected_edges_list;
-    returned2->undirected_edges = undirected_edges;
+
+    free(tmp);
+    free_undirected_edges(&undirected_edges);
+
     return returned2;
-}
-
-
-// Converts all data into forms that can be digested in cython and used to create a graph python object
-ReturnElems* get_raw_data(
-            Node* nodes,
-            long num_nodes,
-            long num_undirected_edges,
-            long num_directed_edges,
-            UndirectedEdge** undirected_edges_list,
-            DirectedEdge** directed_edges_list
-        ) {
-    // NODES ---------------------------
-    // allocate memory to store node information
-    long* node_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long* node_neighbor_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long* node_directed_edge_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long unravel_index  = 0;
-
-    LongToDirectedEdgeList *tmp, *neighbor;
-
-    for (long node_i = 0; node_i < num_nodes; node_i++) {
-        HASH_ITER(hh, nodes[node_i].neighbors, neighbor, tmp) {
-            for (long edge_i = 0; edge_i < neighbor->num_directed_edges_in_group; edge_i++) {
-                node_index_unraveled[unravel_index] = nodes[node_i].index;
-                node_neighbor_index_unraveled[unravel_index] = neighbor->key;
-                node_directed_edge_index_unraveled[unravel_index] = neighbor->directed_edges_list[edge_i]->index;
-                unravel_index += 1;
-            }
-        }
-    }
-
-    // Undirected edges --------------
-    long* undirected_center_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long* undirected_neighbor_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long* undirected_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    long* undirected_directed_edge_indices_unraveled = malloc(sizeof(long) * num_directed_edges);
-    double* undirected_distances_unraveled = malloc(sizeof(double) * num_directed_edges);
-    unravel_index = 0;
-
-    UndirectedEdge* curr_undirected;
-
-    for (long undirected_i = 0; undirected_i < num_undirected_edges; undirected_i++) {
-        curr_undirected = undirected_edges_list[undirected_i];
-        for (long directed_i = 0; directed_i < curr_undirected->num_directed_edges; directed_i++) {
-            undirected_center_index_unraveled[unravel_index] = curr_undirected->nodes.center;
-            undirected_neighbor_index_unraveled[unravel_index] = curr_undirected->nodes.neighbor;
-            undirected_index_unraveled[unravel_index] = curr_undirected->index;
-            undirected_directed_edge_indices_unraveled[unravel_index] = curr_undirected->directed_edge_indices[directed_i];
-            undirected_distances_unraveled[unravel_index] = curr_undirected->distance;
-
-            unravel_index += 1;
-        }
-    }
-
-    // Directed edges ---------------
-    // center unraveled, neighbor unraveled, image unraveled, distance unraveled for directed edges are all
-    // just the inputs to the create graph function
-    long* directed_undirected_edge_index_unraveled = malloc(sizeof(long) * num_directed_edges);
-    for (long directed_i = 0; directed_i < num_directed_edges; directed_i++) {
-        directed_undirected_edge_index_unraveled[directed_i] = directed_edges_list[directed_i]->undirected_edge_index;
-    }
-
-    ReturnElems* returned = malloc(sizeof(ReturnElems));
-    returned->node_index_unraveled = node_index_unraveled;
-    returned->node_neighbor_index_unraveled = node_neighbor_index_unraveled;
-    returned->node_directed_edge_index_unraveled = node_directed_edge_index_unraveled;
-
-    returned->undirected_center_index_unraveled = undirected_center_index_unraveled;
-    returned->undirected_neighbor_index_unraveled = undirected_neighbor_index_unraveled;
-    returned->undirected_index_unraveled = undirected_index_unraveled;
-    returned->undirected_directed_edge_indices_unraveled = undirected_directed_edge_indices_unraveled;
-    returned->undirected_distances_unraveled = undirected_distances_unraveled;
-
-    returned->directed_undirected_edge_index_unraveled = directed_undirected_edge_index_unraveled;
-
-    returned->num_nodes = num_nodes;
-    returned->num_directed_edges = num_directed_edges;
-    returned->num_undirected_edges = num_undirected_edges;
-
-    return returned;
-}
-
-// Returns a list of LongToDirectedEdgeList pointers which are entries for the neighbors of the inputted node
-LongToDirectedEdgeList** get_neighbors(Node* node) {
-    long num_neighbors = HASH_COUNT(node->neighbors);
-    LongToDirectedEdgeList** entries = malloc(sizeof(LongToDirectedEdgeList*) * num_neighbors);
-
-    LongToDirectedEdgeList* entry;
-    long counter = 0;
-    for (entry = node->neighbors; entry != NULL; entry = entry->hh.next) {
-        entries[counter] = entry;
-        counter += 1;
-    }
-
-    return entries;
 }
 
 void print_neighbors(Node* node) {
     LongToDirectedEdgeList *tmp, *neighbor;
     HASH_ITER(hh, node->neighbors, neighbor, tmp) {
         printf("C:neighboring atom: %lu\n", neighbor->key);
+    }
+}
+
+void free_undirected_edges(StructToUndirectedEdgeList** undirected_edges) {
+    StructToUndirectedEdgeList* current;
+    StructToUndirectedEdgeList* tmp;
+
+    HASH_ITER(hh, *undirected_edges, current, tmp) {
+        HASH_DEL(*undirected_edges, current);
+        free(current->undirected_edges_list);
+        free(current);
+    }
+}
+
+void free_LongToDirectedEdgeList_in_nodes(Node* nodes, long num_nodes) {
+    LongToDirectedEdgeList* current;
+    LongToDirectedEdgeList* tmp;
+
+    for (long node_i = 0; node_i < num_nodes; node_i++) {
+        HASH_ITER(hh, nodes[node_i].neighbors, current, tmp) {
+            HASH_DEL(nodes[node_i].neighbors, current);
+            free(current->directed_edges_list);
+            free(current);
+        }
     }
 }
 
@@ -367,7 +270,7 @@ bool is_reversed_directed_edge(DirectedEdge* directed_edge1, DirectedEdge* direc
 }
 
 // If tmp or the reverse of tmp is found in undirected_edges, True is returned and the corresponding StructToUndirectedEdgeList pointer is placed
-// into found_entry. Otherwise, False is returned.
+// into found_entry. Otherwise, False is returned. 
 // NOTE: does not edit the *tmp
 // Assumes *tmp bits have already been 0'd at padding within a struct
 bool find_in_undirected(NodeIndexPair* tmp, StructToUndirectedEdgeList** undirected_edges, StructToUndirectedEdgeList** found_entry) {
@@ -408,7 +311,7 @@ void create_new_undirected_edges_entry(StructToUndirectedEdgeList** undirected_e
     new_entry->num_undirected_edges_in_group = 1;
     new_entry->undirected_edges_list = malloc(sizeof(UndirectedEdge*));
     new_entry->undirected_edges_list[0] = new_undirected_edge;
-
+    
     HASH_ADD(hh, *undirected_edges, key, sizeof(NodeIndexPair), new_entry);
 
 }
@@ -423,7 +326,7 @@ void append_to_undirected_edges_tmp(UndirectedEdge* undirected, StructToUndirect
     long num_undirected_edges = this_undirected_edges_item->num_undirected_edges_in_group;
 
     // No need to worry about originally malloc'ing memory for this_undirected_edges_item->undirected_edges_list
-    // this is because, we first call create_new_undirected_edges_entry for all entries. This function already mallocs for us.
+    // this is because, we first call create_new_undirected_edges_entry for all entires. This function already mallocs for us.
 
     // Realloc the space to fit a new pointer to an undirected edge
     UndirectedEdge** new_list = realloc(this_undirected_edges_item->undirected_edges_list, sizeof(UndirectedEdge*) * (num_undirected_edges + 1));
@@ -452,7 +355,7 @@ void directed_to_undirected(DirectedEdge* directed, UndirectedEdge* undirected, 
 
 void append_to_undirected_edges_list(UndirectedEdge** undirected_edges_list, UndirectedEdge* to_add, long* num_undirected_edges) {
     // No need to realloc for space since our original alloc should cover everything
-
+    
     // Assign value to next available position
     undirected_edges_list[*num_undirected_edges] = to_add;
     *num_undirected_edges += 1;
@@ -461,7 +364,7 @@ void append_to_undirected_edges_list(UndirectedEdge** undirected_edges_list, Und
 void append_to_directed_edges_list(DirectedEdge** directed_edges_list, DirectedEdge* to_add, long* num_directed_edges) {
     // No need to realloc for space since our original alloc should cover everything
 
-    // Assign value to next available position
+    // Assign value to next availabe position
     directed_edges_list[*num_directed_edges] = to_add;
     *num_directed_edges += 1;
 }
@@ -496,10 +399,25 @@ void add_neighbors_to_node(Node* node, long neighbor_index, DirectedEdge* direct
         entry->directed_edges_list = malloc(sizeof(DirectedEdge*));
         entry->directed_edges_list[0] = directed_edge;
         entry->key = neighbor_index;
-
+        
         entry->num_directed_edges_in_group = 1;
         HASH_ADD(hh, node->neighbors, key, sizeof(long), entry);
 
         node->num_neighbors += 1;
     }
+}
+
+// Returns a list of LongToDirectedEdgeList pointers which are entries for the neighbors of the inputted node
+LongToDirectedEdgeList** get_neighbors(Node* node) {
+    long num_neighbors = HASH_COUNT(node->neighbors);
+    LongToDirectedEdgeList** entries = malloc(sizeof(LongToDirectedEdgeList*) * num_neighbors);
+
+    LongToDirectedEdgeList* entry;
+    long counter = 0;
+    for (entry = node->neighbors; entry != NULL; entry = entry->hh.next) {
+        entries[counter] = entry;
+        counter += 1;
+    }
+
+    return entries;
 }

--- a/chgnet/graph/fast_converter_libraries/create_graph.c
+++ b/chgnet/graph/fast_converter_libraries/create_graph.c
@@ -8,7 +8,7 @@ typedef struct _NodeIndexPair NodeIndexPair;
 typedef struct _LongToDirectedEdgeList LongToDirectedEdgeList;
 typedef struct _ReturnElems2 ReturnElems2;
 
-// NOTE: This code was mainly written to replicate the original add_edges method 
+// NOTE: This code was mainly written to replicate the original add_edges method
 // in the graph class in chgnet.graph.graph such that anyone familiar with that code should be able to pick up this
 // code pretty easily.
 
@@ -117,7 +117,7 @@ ReturnElems2* create_graph(
     StructToUndirectedEdgeList* undirected_edges = NULL;
 
     // Pointer to beginning of list of UndirectedEdges corresponding to tmp of current iteration
-    StructToUndirectedEdgeList* corr_undirected_edges_item = NULL; 
+    StructToUndirectedEdgeList* corr_undirected_edges_item = NULL;
 
     // Pointer to NodeIndexPair storing tmp
     NodeIndexPair* tmp = malloc(sizeof(NodeIndexPair));
@@ -126,7 +126,7 @@ ReturnElems2* create_graph(
     bool found = false;
 
     // Flag used to show if we've already processed the current undirected edge
-    bool processed_edge = false; 
+    bool processed_edge = false;
 
     // Pointer used to store the previously added directed edge between two nodes
     DirectedEdge* added_DE;
@@ -166,9 +166,9 @@ ReturnElems2* create_graph(
             create_new_undirected_edges_entry(&undirected_edges, tmp, this_undirected_edge);
             append_to_undirected_edges_list(undirected_edges_list, this_undirected_edge, &num_undirected_edges);
             add_neighbors_to_node(&nodes[center_indices[i]], neighbor_indices[i], this_directed_edge);
-            append_to_directed_edges_list(directed_edges_list, this_directed_edge, &num_directed_edges);    
+            append_to_directed_edges_list(directed_edges_list, this_directed_edge, &num_directed_edges);
         } else {
-            // This pair of nodes has been added before. We have to check if it's the other directed edge (but pointed in 
+            // This pair of nodes has been added before. We have to check if it's the other directed edge (but pointed in
             // the different direction) OR it's another totally different undirected edge that has different image and distance
 
             // if found is true, then corr_undirected_edges_item points to self.undirected_edges[tmp]
@@ -207,7 +207,7 @@ ReturnElems2* create_graph(
     returned2->num_nodes = num_atoms;
     returned2->num_undirected_edges = num_undirected_edges;
     returned2->num_directed_edges = num_directed_edges;
-    
+
     returned2->nodes = nodes;
     returned2->directed_edges_list = directed_edges_list;
     returned2->undirected_edges_list = undirected_edges_list;
@@ -270,7 +270,7 @@ bool is_reversed_directed_edge(DirectedEdge* directed_edge1, DirectedEdge* direc
 }
 
 // If tmp or the reverse of tmp is found in undirected_edges, True is returned and the corresponding StructToUndirectedEdgeList pointer is placed
-// into found_entry. Otherwise, False is returned. 
+// into found_entry. Otherwise, False is returned.
 // NOTE: does not edit the *tmp
 // Assumes *tmp bits have already been 0'd at padding within a struct
 bool find_in_undirected(NodeIndexPair* tmp, StructToUndirectedEdgeList** undirected_edges, StructToUndirectedEdgeList** found_entry) {
@@ -311,7 +311,7 @@ void create_new_undirected_edges_entry(StructToUndirectedEdgeList** undirected_e
     new_entry->num_undirected_edges_in_group = 1;
     new_entry->undirected_edges_list = malloc(sizeof(UndirectedEdge*));
     new_entry->undirected_edges_list[0] = new_undirected_edge;
-    
+
     HASH_ADD(hh, *undirected_edges, key, sizeof(NodeIndexPair), new_entry);
 
 }
@@ -326,7 +326,7 @@ void append_to_undirected_edges_tmp(UndirectedEdge* undirected, StructToUndirect
     long num_undirected_edges = this_undirected_edges_item->num_undirected_edges_in_group;
 
     // No need to worry about originally malloc'ing memory for this_undirected_edges_item->undirected_edges_list
-    // this is because, we first call create_new_undirected_edges_entry for all entires. This function already mallocs for us.
+    // this is because, we first call create_new_undirected_edges_entry for all entries. This function already mallocs for us.
 
     // Realloc the space to fit a new pointer to an undirected edge
     UndirectedEdge** new_list = realloc(this_undirected_edges_item->undirected_edges_list, sizeof(UndirectedEdge*) * (num_undirected_edges + 1));
@@ -355,7 +355,7 @@ void directed_to_undirected(DirectedEdge* directed, UndirectedEdge* undirected, 
 
 void append_to_undirected_edges_list(UndirectedEdge** undirected_edges_list, UndirectedEdge* to_add, long* num_undirected_edges) {
     // No need to realloc for space since our original alloc should cover everything
-    
+
     // Assign value to next available position
     undirected_edges_list[*num_undirected_edges] = to_add;
     *num_undirected_edges += 1;
@@ -364,7 +364,7 @@ void append_to_undirected_edges_list(UndirectedEdge** undirected_edges_list, Und
 void append_to_directed_edges_list(DirectedEdge** directed_edges_list, DirectedEdge* to_add, long* num_directed_edges) {
     // No need to realloc for space since our original alloc should cover everything
 
-    // Assign value to next availabe position
+    // Assign value to next available position
     directed_edges_list[*num_directed_edges] = to_add;
     *num_directed_edges += 1;
 }
@@ -399,7 +399,7 @@ void add_neighbors_to_node(Node* node, long neighbor_index, DirectedEdge* direct
         entry->directed_edges_list = malloc(sizeof(DirectedEdge*));
         entry->directed_edges_list[0] = directed_edge;
         entry->key = neighbor_index;
-        
+
         entry->num_directed_edges_in_group = 1;
         HASH_ADD(hh, node->neighbors, key, sizeof(long), entry);
 


### PR DESCRIPTION
Fixed memory leak problem within `create_graph.c` and `cygraph.pyx`.