### PR TITLE
Publish pre-compiled wheels for all platforms to PyPI in release CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -59,7 +59,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build dist
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,21 +50,63 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
 
-  release:
-    runs-on: ubuntu-latest
+  build_source_dist:
     needs: tests
+    runs-on: ubuntu-latest
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.task == 'release')
-    permissions:
-      # For PyPI trusted publishing
-      id-token: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Build dist
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.10"
+
+      - name: Build source distribution
         run: |
           pip install build
-          python -m build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels for ${{ matrix.os }}
+    needs: tests
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.task == 'release')
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["39", "310", "311"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_BUILD: cp${{ matrix.python-version }}-*
+
+      - name: Save artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse
+
+  release:
+    needs: [build_wheels, build_source_dist]
+    runs-on: ubuntu-latest
+    permissions:
+      # For pypi trusted publishing
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
 
       - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,7 @@
 from __future__ import annotations
 
 from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext
 
+ext_modules = [Extension("chgnet.graph.cygraph", ["chgnet/graph/cygraph.pyx"])]
 
-class BuildExt(build_ext):
-    """Custom build extension."""
-
-    def finalize_options(self):
-        """Override finalize_options to ensure we don't run cythonize when making
-        a source distribution.
-        """
-        import Cython.Build
-
-        self.distribution.ext_modules = Cython.Build.cythonize(
-            [Extension("chgnet.graph.cygraph", ["chgnet/graph/cygraph.pyx"])]
-        )
-        super().finalize_options()
-
-
-setup(cmdclass={"build_ext": BuildExt})
+setup(ext_modules=ext_modules, setup_requires=["Cython"])


### PR DESCRIPTION
@BowenD-UCB @AegisIK Here's a rough draft for publishing pre-compiled wheels for all platforms to PyPI. This probably doesn't work yet but needs to be debugged by actually running in CI.