### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![GitHub repo size](https://img.shields.io/github/repo-size/CederGroupHub/chgnet)
 [![PyPI](https://img.shields.io/pypi/v/chgnet?logo=pypi&logoColor=white)](https://pypi.org/project/chgnet?logo=pypi&logoColor=white)
 [![Docs](https://img.shields.io/badge/API-Docs-blue)](https://chgnet.lbl.gov)
+[![Requires Python 3.9+](https://img.shields.io/badge/Python-3.9+-blue.svg?logo=python&logoColor=white)](https://python.org/downloads)
 
 </h4>
 

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -4,7 +4,7 @@ import functools
 import os
 import random
 import warnings
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -17,6 +17,8 @@ from chgnet import utils
 from chgnet.graph import CrystalGraph, CrystalGraphConverter
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from chgnet import TrainTask
 
 warnings.filterwarnings("ignore")
@@ -81,7 +83,7 @@ class StructureData(Dataset):
         """Get the number of structures in this dataset."""
         return len(self.keys)
 
-    @functools.lru_cache(maxsize=None)  # Cache loaded structures
+    @functools.cache  # Cache loaded structures
     def __getitem__(self, idx: int) -> tuple[CrystalGraph, dict]:
         """Get one graph for a structure in this dataset.
 
@@ -188,7 +190,7 @@ class CIFData(Dataset):
         """Get the number of structures in this dataset."""
         return len(self.cif_ids)
 
-    @functools.lru_cache(maxsize=None)  # Cache loaded structures
+    @functools.cache  # Cache loaded structures
     def __getitem__(self, idx: int) -> tuple[CrystalGraph, dict[str, Tensor]]:
         """Get one item in the dataset.
 
@@ -535,7 +537,7 @@ class StructureJsonData(Dataset):
         """Get the number of structures with targets in the dataset."""
         return len(self.keys)
 
-    @functools.lru_cache(maxsize=None)  # Cache loaded structures
+    @functools.cache  # Cache loaded structures
     def __getitem__(self, idx):
         """Get one item in the dataset.
 

--- a/chgnet/model/basis.py
+++ b/chgnet/model/basis.py
@@ -140,9 +140,9 @@ class GaussianExpansion(nn.Module):
         assert min < max
         assert max - min > step
         self.register_buffer("gaussian_centers", torch.arange(min, max + step, step))
-        if var is None:
-            var = step
-        self.var = var
+        self.var = var or step
+        if self.var <= 0:
+            raise ValueError(f"{var=} must be positive")
 
     def expand(self, features: Tensor) -> Tensor:
         """Apply Gaussian filter to a feature Tensor.
@@ -152,7 +152,7 @@ class GaussianExpansion(nn.Module):
 
         Returns:
             expanded features (Tensor): tensor of Gaussian distances [n, dim]
-            where the expanded dimension will be (dmax-dmin)/step + 1
+            where the expanded dimension will be (dmax - dmin) / step + 1
         """
         return torch.exp(
             -((features.reshape(-1, 1) - self.gaussian_centers) ** 2) / self.var**2

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -11,6 +11,8 @@ from torch import Tensor, nn
 from chgnet.model.functions import GatedMLP, find_activation
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from chgnet.graph.crystalgraph import CrystalGraph
 
 

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor, nn

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import math
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Sequence
+from typing import TYPE_CHECKING, Literal
 
 import torch
 from pymatgen.core import Structure

--- a/examples/basics.ipynb
+++ b/examples/basics.ipynb
@@ -285,7 +285,6 @@
     "    trajectory=\"md_out.traj\",\n",
     "    logfile=\"md_out.log\",\n",
     "    loginterval=100,\n",
-    "    use_device=\"cpu\",  # use 'cuda' for faster MD, if not specified, CHGNet will automatically search for CUDA\n",
     ")\n",
     "md.run(50)  # run a 0.1 ps MD simulation"
    ]

--- a/examples/crystaltoolkit_relax_viewer.ipynb
+++ b/examples/crystaltoolkit_relax_viewer.ipynb
@@ -45,7 +45,7 @@
    ],
    "source": [
     "try:\n",
-    "    import chgnet\n",
+    "    import chgnet  # noqa: F401\n",
     "except ImportError:\n",
     "    # install CHGNet with extra dependencies to run the dash app in this notebook\n",
     "    # https://github.com/materialsproject/crystaltoolkit\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "chgnet"
 version = "0.2.0"
 description = "Pretrained Universal Neural Network Potential for Charge-informed Atomistic Modeling"
 authors = [{ name = "Bowen Deng", email = "bowendeng@berkeley.edu" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = { text = "Modified BSD" }
 dependencies = [
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Chemistry",
@@ -49,7 +48,7 @@ find = { include = ["chgnet*"], exclude = ["tests", "tests*"] }
 "chgnet.pretrained" = ["*.tar"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 95
 include = ["**/pyproject.toml", "*.ipynb", "*.py", "*.pyi"]
 select = [


### PR DESCRIPTION
Let's [follow the ecosystem](https://github.com/materialsproject/pymatgen/pull/3283) and drop Python 3.8 support. Supported Python versions going forward are 3.9, 3.10 and 3.11.