### PR TITLE
Remove MPS comment from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ trainer.train(train_loader, val_loader, test_loader)
 5. To save time from graph conversion step for each training, we recommend you use [`GraphData`](https://github.com/CederGroupHub/chgnet/blob/main/chgnet/data/dataset.py) defined in
    [`dataset.py`](https://github.com/CederGroupHub/chgnet/blob/main/chgnet/data/dataset.py), which reads graphs directly from saved directory. To create saved graphs,
    see [`examples/make_graphs.py`](https://github.com/CederGroupHub/chgnet/blob/main/examples/make_graphs.py).
-6. The Pytorch `MPS` backend (Apple’s Metal Performance Shaders) is currently disabled until a stable version of `pytorch` for `MPS` is released.
 
 ## MPtrj Dataset
 


### PR DESCRIPTION
The README has the following line:

> 6. The Pytorch `MPS` backend (Apple’s Metal Performance Shaders) is currently disabled until a stable version of `pytorch` for `MPS` is released.

Looks like this was solvd in https://github.com/CederGroupHub/chgnet/commit/516c422f3bb8ee4d0dd75459ef4fa4ccd61baef0, so I removed the line from the README.