### PR TITLE
Hashable edges

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -106,8 +106,14 @@ def test_directed_edge() -> None:
     assert edge.index == 0
     assert repr(edge) == f"DirectedEdge(nodes=[0, 1], index=0, {info=})"
 
+    # test hashable
+    _ = {edge}
+
 
 def test_undirected_edge() -> None:
     info = {"image": np.array([0, 0, 0]), "distance": 1.0}
     edge = UndirectedEdge([0, 1], index=0, info=info)
     assert repr(edge) == f"UndirectedEdge(nodes=[0, 1], index=0, {info=})"
+
+    # test hashable
+    _ = {edge}


### PR DESCRIPTION
d0aa03b make `DirectedEdge` and `UndirectedEdge` inherit from new `Edge` abstract base class, make them hashable, handle missing `info['image']` gracefully in `DirectedEdge.__eq__`
cffaa6b check `(Un)directedEdge` is hashable in `test_(un)directed_edge`