### PR TITLE
Use `torch.det` to calculate volumes

### DIFF
--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -807,7 +807,7 @@ class BatchedGraph:
             else:
                 strain = None
                 lattice = graph.lattice
-            volumes.append(torch.dot(lattice[0], torch.cross(lattice[1], lattice[2])))
+            volumes.append(torch.det(lattice))
             strains.append(strain)
 
             # Bonds


### PR DESCRIPTION

## Summary

`torch.cross` without `dim` is deprecated.

## Todos

I'm not sure whether we need a `torch.abs` here.