### PR TITLE
Use MPS backend if available and `use_device=None`, add `CHGNET_DEVICE` env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,9 @@ jobs:
           pip install -e .[test]
 
       - name: Run Tests
-        run: CHGNET_DEVICE=cpu pytest --capture=no --cov --cov-report=xml .
+        run: pytest --capture=no --cov --cov-report=xml .
+        env:
+          CHGNET_DEVICE: cpu
 
       - name: Codacy coverage reporter
         if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -e .[test]
 
       - name: Run Tests
-        run: pytest --capture=no --cov --cov-report=xml .
+        run: PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 pytest --capture=no --cov --cov-report=xml .
 
       - name: Codacy coverage reporter
         if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           pip install -e .[test]
 
       - name: Run Tests
-        run: PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 pytest --capture=no --cov --cov-report=xml .
+        run: CHGNET_DEVICE=cpu pytest --capture=no --cov --cov-report=xml .
 
       - name: Codacy coverage reporter
         if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import io
+import os
 import pickle
 import sys
 from typing import TYPE_CHECKING, Literal
@@ -81,6 +82,7 @@ class CHGNetCalculator(Calculator):
         super().__init__(**kwargs)
 
         # Determine the device to use
+        use_device = use_device or os.getenv("CHGNET_DEVICE")
         if use_device in ("mps", None) and torch.backends.mps.is_available():
             self.device = "mps"
         else:

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -51,7 +51,7 @@ OPTIMIZERS = {
 class CHGNetCalculator(Calculator):
     """CHGNet Calculator for ASE applications."""
 
-    implemented_properties = ("energy", "forces", "stress", "magmoms")
+    implemented_properties = ("energy", "forces", "stress", "magmoms")  # type: ignore
 
     def __init__(
         self,
@@ -81,7 +81,7 @@ class CHGNetCalculator(Calculator):
         super().__init__(**kwargs)
 
         # Determine the device to use
-        if use_device == "mps" and torch.backends.mps.is_available():
+        if use_device in ("mps", None) and torch.backends.mps.is_available():
             self.device = "mps"
         else:
             self.device = use_device or ("cuda" if torch.cuda.is_available() else "cpu")
@@ -95,7 +95,7 @@ class CHGNetCalculator(Calculator):
         print(f"CHGNet will run on {self.device}")
 
     @property
-    def version(self) -> str:
+    def version(self) -> str | None:
         """The version of CHGNet."""
         return self.model.version
 

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -707,6 +707,7 @@ class CHGNet(nn.Module):
         )
 
         # Determine the device to use
+        use_device = use_device or os.getenv("CHGNET_DEVICE")
         if use_device in ("mps", None) and torch.backends.mps.is_available():
             device = "mps"
         else:

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -707,7 +707,7 @@ class CHGNet(nn.Module):
         )
 
         # Determine the device to use
-        if use_device == "mps" and torch.backends.mps.is_available():
+        if use_device in ("mps", None) and torch.backends.mps.is_available():
             device = "mps"
         else:
             device = use_device or ("cuda" if torch.cuda.is_available() else "cpu")
@@ -763,7 +763,7 @@ class BatchedGraph:
     directed2undirected: Tensor
     atom_positions: Sequence[Tensor]
     strains: Sequence[Tensor]
-    volumes: Sequence[Tensor]
+    volumes: Sequence[Tensor] | Tensor
 
     @classmethod
     def from_graphs(
@@ -790,8 +790,7 @@ class BatchedGraph:
         batched_atom_graph, batched_bond_graph = [], []
         directed2undirected = []
         atom_owners = []
-        atom_offset_idx = 0
-        n_undirected = 0
+        atom_offset_idx = n_undirected = 0
 
         for graph_idx, graph in enumerate(graphs):
             # Atoms

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -806,7 +806,7 @@ class BatchedGraph:
             else:
                 strain = None
                 lattice = graph.lattice
-            volumes.append(torch.det(lattice))
+            volumes.append(torch.dot(lattice[0], torch.cross(lattice[1], lattice[2])))
             strains.append(strain)
 
             # Bonds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ find = { include = ["chgnet*"], exclude = ["tests", "tests*"] }
 [tool.ruff]
 target-version = "py39"
 include = ["**/pyproject.toml", "*.ipynb", "*.py", "*.pyi"]
+[tool.ruff.lint]
 select = [
     "B",    # flake8-bugbear
     "C4",   # flake8-comprehensions
@@ -94,6 +95,7 @@ ignore = [
     "D104",    # Missing docstring in public package
     "D205",    # 1 blank line required between summary line and description
     "DTZ005",  # use of datetime.now() without timezone
+    "E731",    # do not assign a lambda expression, use a def
     "EM",
     "ERA001",  # found commented out code
     "FBT001",  # Boolean positional argument in function
@@ -114,7 +116,7 @@ pydocstyle.convention = "google"
 isort.required-imports = ["from __future__ import annotations"]
 isort.split-on-trailing-comma = false
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "site/*" = ["INP001", "S602"]
 "tests/*" = ["ANN201", "D103", "INP001", "S101"]
 # E402 Module level import not at top of file


### PR DESCRIPTION
prev would default to CPU in that case. we should default to the fastest hardware available on Mac.

this also ensures we test MPS backend in CI to catch breaking changes as in #130