### PR TITLE
Revert `torch.det` for MPS support

### DIFF
--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -807,7 +807,11 @@ class BatchedGraph:
             else:
                 strain = None
                 lattice = graph.lattice
-            volumes.append(torch.linalg.vecdot(lattice[0], torch.linalg.cross(lattice[1], lattice[2])))
+            volumes.append(
+                torch.linalg.vecdot(
+                    lattice[0], torch.linalg.cross(lattice[1], lattice[2])
+                )
+            )
             strains.append(strain)
 
             # Bonds

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -807,7 +807,7 @@ class BatchedGraph:
             else:
                 strain = None
                 lattice = graph.lattice
-            volumes.append(torch.det(lattice))
+            volumes.append(torch.linalg.vecdot(lattice[0], torch.linalg.cross(lattice[1], lattice[2])))
             strains.append(strain)
 
             # Bonds


### PR DESCRIPTION
## Summary

Use `torch.linalg.cross` to suppress deprecated warning raised by `torch >= 2.2`.

Also, since `torch.det` utilises LU decomposition to calculate the determinant, I prefer to use the more direct way (_i.e._, mixed product) to calculate volumes even if `torch.det` gets MPS support in the future.