### PR TITLE
Fix "Failed to CreateArtifact" on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: wheelhouse
+          # https://github.com/actions/upload-artifact/issues/478#issuecomment-1885470013
+          name: dist-${{ matrix.os }}-${{ matrix.python-version }}
 
   release:
     name: Release wheels and source distribution to PyPI
@@ -74,6 +76,8 @@ jobs:
         with:
           name: artifact
           path: dist
+          merge-multiple: true
+          pattern: dist-*
 
       - name: Publish to PyPi or TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
[Error (409) Conflict: an artifact with this name already exists on the workflow run](https://github.com/CederGroupHub/chgnet/actions/runs/8668824033/job/23911654375)

reported in https://github.com/actions/upload-artifact/issues/478. not sure if this fix is correct (adapted from [migration guide](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)). another option would be to revert to `upload-artifact@v3` for the time being.