### PR TITLE
`ruff` fixes + type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.4.4
     hooks:
       - id: ruff
         args: [--fix]
@@ -46,7 +46,7 @@ repos:
           - svelte
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.2.0
+    rev: v9.3.0
     hooks:
       - id: eslint
         types: [file]

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -64,7 +64,7 @@ class StructureData(Dataset):
         """
         for idx, struct in enumerate(structures):
             if not isinstance(struct, Structure):
-                raise ValueError(f"{idx} is not a pymatgen Structure object: {struct}")
+                raise TypeError(f"{idx} is not a pymatgen Structure object: {struct}")
         for name in "energies forces stresses magmoms structure_ids".split():
             labels = locals()[name]
             if labels is not None and len(labels) != len(structures):
@@ -97,7 +97,7 @@ class StructureData(Dataset):
         save_path: str | None = None,
         graph_converter: CrystalGraphConverter | None = None,
         shuffle: bool = True,
-    ):
+    ) -> StructureData:
         """Parse VASP output files into structures and labels and feed into the dataset.
 
         Args:
@@ -586,7 +586,7 @@ class StructureJsonData(Dataset):
         elif isinstance(data, dict):
             self.data = data
         else:
-            raise ValueError(f"data must be JSON path or dictionary, got {type(data)}")
+            raise TypeError(f"data must be JSON path or dictionary, got {type(data)}")
 
         self.keys = [
             (mp_id, graph_id) for mp_id, dct in self.data.items() for graph_id in dct
@@ -608,7 +608,7 @@ class StructureJsonData(Dataset):
         return len(self.keys)
 
     @functools.cache  # Cache loaded structures
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[CrystalGraph, dict[str, Tensor]]:
         """Get one item in the dataset.
 
         Returns:
@@ -754,7 +754,7 @@ class StructureJsonData(Dataset):
         return train_loader, val_loader, test_loader
 
 
-def collate_graphs(batch_data: list):
+def collate_graphs(batch_data: list) -> tuple[list[CrystalGraph], dict[str, Tensor]]:
     """Collate of list of (graph, target) into batch data.
 
     Args:
@@ -791,7 +791,7 @@ def get_train_val_test_loader(
     return_test: bool = True,
     num_workers: int = 0,
     pin_memory: bool = True,
-):
+) -> tuple[DataLoader, DataLoader, DataLoader]:
     """Randomly partition a dataset into train, val, test loaders.
 
     Args:
@@ -852,7 +852,7 @@ def get_train_val_test_loader(
 
 def get_loader(
     dataset, *, batch_size: int = 64, num_workers: int = 0, pin_memory: bool = True
-):
+) -> DataLoader:
     """Get a dataloader from a dataset.
 
     Args:

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -33,6 +33,7 @@ class StructureData(Dataset):
         structures: list[Structure],
         energies: list[float],
         forces: list[Sequence[Sequence[float]]],
+        *,
         stresses: list[Sequence[Sequence[float]]] | None = None,
         magmoms: list[Sequence[Sequence[float]]] | None = None,
         structure_ids: list | None = None,
@@ -91,6 +92,7 @@ class StructureData(Dataset):
     def from_vasp(
         cls,
         file_root: str,
+        *,
         check_electronic_convergence: bool = True,
         save_path: str | None = None,
         graph_converter: CrystalGraphConverter | None = None,
@@ -196,6 +198,7 @@ class CIFData(Dataset):
     def __init__(
         self,
         cif_path: str,
+        *,
         labels: str | dict = "labels.json",
         targets: TrainTask = "efsm",
         graph_converter: CrystalGraphConverter | None = None,
@@ -311,6 +314,7 @@ class GraphData(Dataset):
     def __init__(
         self,
         graph_path: str,
+        *,
         labels: str | dict = "labels.json",
         targets: TrainTask = "efsm",
         exclude: str | list | None = None,
@@ -429,6 +433,7 @@ class GraphData(Dataset):
         self,
         train_ratio: float = 0.8,
         val_ratio: float = 0.1,
+        *,
         train_key: list[str] | None = None,
         val_key: list[str] | None = None,
         test_key: list[str] | None = None,
@@ -541,6 +546,7 @@ class StructureJsonData(Dataset):
         self,
         data: str | dict,
         graph_converter: CrystalGraphConverter,
+        *,
         targets: TrainTask = "efsm",
         energy_key: str = "energy_per_atom",
         force_key: str = "force",
@@ -654,6 +660,7 @@ class StructureJsonData(Dataset):
         self,
         train_ratio: float = 0.8,
         val_ratio: float = 0.1,
+        *,
         train_key: list[str] | None = None,
         val_key: list[str] | None = None,
         test_key: list[str] | None = None,
@@ -777,6 +784,7 @@ def collate_graphs(batch_data: list):
 
 def get_train_val_test_loader(
     dataset: Dataset,
+    *,
     batch_size: int = 64,
     train_ratio: float = 0.8,
     val_ratio: float = 0.1,
@@ -842,7 +850,9 @@ def get_train_val_test_loader(
     return train_loader, val_loader
 
 
-def get_loader(dataset, batch_size=64, num_workers=0, pin_memory=True):
+def get_loader(
+    dataset, *, batch_size: int = 64, num_workers: int = 0, pin_memory: bool = True
+):
     """Get a dataloader from a dataset.
 
     Args:

--- a/chgnet/data/dataset.py
+++ b/chgnet/data/dataset.py
@@ -80,7 +80,7 @@ class StructureData(Dataset):
         self.keys = np.arange(len(structures))
         if shuffle:
             random.shuffle(self.keys)
-        print(f"{len(structures)} structures imported")
+        print(f"{type(self).__name__} imported {len(structures):,} structures")
         self.graph_converter = graph_converter or CrystalGraphConverter(
             atom_graph_cutoff=6, bond_graph_cutoff=3
         )
@@ -587,7 +587,7 @@ class StructureJsonData(Dataset):
         ]
         if shuffle:
             random.shuffle(self.keys)
-        print(f"{len(self.data)} mp_ids, {len(self)} structures imported")
+        print(f"{len(self.data)} MP IDs, {len(self)} structures imported")
         self.graph_converter = graph_converter
         self.energy_key = energy_key
         self.force_key = force_key

--- a/chgnet/graph/converter.py
+++ b/chgnet/graph/converter.py
@@ -33,6 +33,7 @@ class CrystalGraphConverter(nn.Module):
 
     def __init__(
         self,
+        *,
         atom_graph_cutoff: float = 6,
         bond_graph_cutoff: float = 3,
         algorithm: Literal["legacy", "fast"] = "fast",

--- a/chgnet/graph/converter.py
+++ b/chgnet/graph/converter.py
@@ -274,7 +274,6 @@ class CrystalGraphConverter(nn.Module):
             None
         """
         self.on_isolated_atoms = on_isolated_atoms
-        return
 
     def as_dict(self) -> dict[str, str | float]:
         """Save the args of the graph converter."""

--- a/chgnet/graph/crystalgraph.py
+++ b/chgnet/graph/crystalgraph.py
@@ -183,7 +183,7 @@ class CrystalGraph:
         )
 
     @property
-    def num_isolated_atoms(self):
+    def num_isolated_atoms(self) -> int:
         """Number of isolated atoms given the atom graph cutoff
         Isolated atoms are disconnected nodes in the atom graph
         that will not get updated in CHGNet.

--- a/chgnet/graph/graph.py
+++ b/chgnet/graph/graph.py
@@ -66,7 +66,7 @@ class UndirectedEdge(Edge):
 
     __hash__ = Edge.__hash__
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """Check if two undirected edges are equal."""
         return set(self.nodes) == set(other.nodes) and self.info == other.info
 
@@ -178,16 +178,16 @@ class Graph:
                 ):
                     # There is an undirected edge with similar length and only one of
                     # the directed edges associated has been added
-                    added_DE = self.directed_edges_list[
+                    added_dir_edge = self.directed_edges_list[
                         undirected_edge.info["directed_edge_index"][0]
                     ]
 
                     # See if the DE that's associated to this UDE
                     # is the reverse of our DE
-                    if added_DE == this_directed_edge:
+                    if added_dir_edge == this_directed_edge:
                         # Add UDE index to this DE
                         this_directed_edge.info["undirected_edge_index"] = (
-                            added_DE.info["undirected_edge_index"]
+                            added_dir_edge.info["undirected_edge_index"]
                         )
 
                         # At the center node, draw edge with this DE
@@ -217,7 +217,7 @@ class Graph:
             self.nodes[center_index].add_neighbor(neighbor_index, this_directed_edge)
             self.directed_edges_list.append(this_directed_edge)
 
-    def adjacency_list(self):
+    def adjacency_list(self) -> tuple[list[list[int]], list[int]]:
         """Get the adjacency list
         Return:
             graph: the adjacency list
@@ -240,7 +240,7 @@ class Graph:
         ]
         return graph, directed2undirected
 
-    def line_graph_adjacency_list(self, cutoff):
+    def line_graph_adjacency_list(self, cutoff) -> tuple[list[list[int]], list[int]]:
         """Get the line graph adjacency list.
 
         Args:
@@ -264,11 +264,12 @@ class Graph:
                 a list of length = num_undirected_edge that
                 maps the undirected edge index to one of its directed edges indices
         """
-        assert len(self.directed_edges_list) == 2 * len(self.undirected_edges_list), (
-            f"Error: number of directed edges={len(self.directed_edges_list)} != 2 * "
-            f"number of undirected edges={len(self.directed_edges_list)}!"
-            f"This indicates directed edges are not complete"
-        )
+        if len(self.directed_edges_list) != 2 * len(self.undirected_edges_list):
+            raise ValueError(
+                f"Error: number of directed edges={len(self.directed_edges_list)} != 2 "
+                f"* number of undirected edges={len(self.directed_edges_list)}!"
+                f"This indicates directed edges are not complete"
+            )
         line_graph = []
         undirected2directed = []
 
@@ -285,14 +286,15 @@ class Graph:
             # if encountered exception,
             # it means after Atom_Graph creation, the UDE has only 1 DE associated
             # This exception is not encountered from the develop team's experience
-            assert len(u_edge.info["directed_edge_index"]) == 2, (
-                "Did not find 2 Directed_edges !!!"
-                f"undirected edge {u_edge} has:"
-                f"edge.info['directed_edge_index'] = "
-                f"{u_edge.info['directed_edge_index']}"
-                f"len directed_edges_list = {len(self.directed_edges_list)}"
-                f"len undirected_edges_list = {len(self.undirected_edges_list)}"
-            )
+            if len(u_edge.info["directed_edge_index"]) != 2:
+                raise ValueError(
+                    "Did not find 2 Directed_edges !!!"
+                    f"undirected edge {u_edge} has:"
+                    f"edge.info['directed_edge_index'] = "
+                    f"{u_edge.info['directed_edge_index']}"
+                    f"len directed_edges_list = {len(self.directed_edges_list)}"
+                    f"len undirected_edges_list = {len(self.undirected_edges_list)}"
+                )
 
             # This UDE is valid to be considered as a node in Bond_Graph
 
@@ -300,24 +302,26 @@ class Graph:
             # DE1 should have center=center1 and DE2 should have center=center2
             # We will need to find directed edges with center = center1
             # and create angles with DE1, then do the same for center2 and DE2
-            for center, DE in zip(u_edge.nodes, u_edge.info["directed_edge_index"]):
+            for center, dir_edge in zip(
+                u_edge.nodes, u_edge.info["directed_edge_index"]
+            ):
                 for directed_edges in self.nodes[center].neighbors.values():
                     for directed_edge in directed_edges:
-                        if directed_edge.index == DE:
+                        if directed_edge.index == dir_edge:
                             continue
                         if directed_edge.info["distance"] < cutoff:
                             line_graph.append(
                                 [
                                     center,
                                     u_edge.index,
-                                    DE,
+                                    dir_edge,
                                     directed_edge.info["undirected_edge_index"],
                                     directed_edge.index,
                                 ]
                             )
         return line_graph, undirected2directed
 
-    def undirected2directed(self):
+    def undirected2directed(self) -> list[int]:
         """The index map from undirected_edge index to one of its directed_edge
         index.
         """
@@ -326,7 +330,7 @@ class Graph:
             for undirected_edge in self.undirected_edges_list
         ]
 
-    def as_dict(self):
+    def as_dict(self) -> dict:
         """Return dictionary serialization of a Graph."""
         return {
             "nodes": self.nodes,

--- a/chgnet/model/basis.py
+++ b/chgnet/model/basis.py
@@ -123,8 +123,8 @@ class GaussianExpansion(nn.Module):
 
     def __init__(
         self,
-        min: float = 0,
-        max: float = 5,
+        min: float = 0,  # noqa: A002
+        max: float = 5,  # noqa: A002
         step: float = 0.5,
         var: float | None = None,
     ) -> None:
@@ -138,8 +138,10 @@ class GaussianExpansion(nn.Module):
             var (float): variance in gaussian filter, default to step
         """
         super().__init__()
-        assert min < max
-        assert max - min > step
+        if min >= max:
+            raise ValueError(f"{min=} must be less than {max=}")
+        if max - min <= step:
+            raise ValueError(f"{max - min=} must be greater than {step=}")
         self.register_buffer("gaussian_centers", torch.arange(min, max + step, step))
         self.var = var or step
         if self.var <= 0:

--- a/chgnet/model/basis.py
+++ b/chgnet/model/basis.py
@@ -8,7 +8,7 @@ from torch import Tensor, nn
 class Fourier(nn.Module):
     """Fourier Expansion for angle features."""
 
-    def __init__(self, order: int = 5, learnable: bool = False) -> None:
+    def __init__(self, *, order: int = 5, learnable: bool = False) -> None:
         """Initialize the Fourier expansion.
 
         Args:
@@ -47,6 +47,7 @@ class RadialBessel(torch.nn.Module):
 
     def __init__(
         self,
+        *,
         num_radial: int = 9,
         cutoff: float = 5,
         learnable: bool = False,
@@ -90,7 +91,7 @@ class RadialBessel(torch.nn.Module):
             self.smooth_cutoff = None
 
     def forward(
-        self, dist: Tensor, return_smooth_factor: bool = False
+        self, dist: Tensor, *, return_smooth_factor: bool = False
     ) -> Tensor | tuple[Tensor, Tensor]:
         """Apply Bessel expansion to a feature Tensor.
 

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -63,7 +63,7 @@ class CompositionModel(nn.Module):
         composition_feas = self._assemble_graphs(graphs)
         return self._get_energy(composition_feas)
 
-    def _assemble_graphs(self, graphs: list[CrystalGraph]):
+    def _assemble_graphs(self, graphs: list[CrystalGraph]) -> Tensor:
         """Assemble a list of graphs into one-hot composition encodings.
 
         Args:
@@ -99,7 +99,7 @@ class AtomRef(nn.Module):
         self.fc = nn.Linear(max_num_elements, 1, bias=False)
         self.fitted = False
 
-    def forward(self, graphs: list[CrystalGraph]):
+    def forward(self, graphs: list[CrystalGraph]) -> Tensor:
         """Get the energy of a list of CrystalGraphs.
 
         Args:
@@ -108,7 +108,8 @@ class AtomRef(nn.Module):
         Returns:
             energy (tensor)
         """
-        assert self.fitted is True, "composition model need to be fitted first!"
+        if not self.fitted:
+            raise ValueError("composition model needs to be fitted first!")
         composition_feas = self._assemble_graphs(graphs)
         return self._get_energy(composition_feas)
 
@@ -171,7 +172,7 @@ class AtomRef(nn.Module):
         self.fc.load_state_dict(state_dict)
         self.fitted = True
 
-    def _assemble_graphs(self, graphs: list[CrystalGraph]):
+    def _assemble_graphs(self, graphs: list[CrystalGraph]) -> Tensor:
         """Assemble a list of graphs into one-hot composition encodings
         Args:
             graphs (list[Tensor]): a list of CrystalGraphs
@@ -189,7 +190,7 @@ class AtomRef(nn.Module):
             composition_feas.append(composition_fea)
         return torch.stack(composition_feas, dim=0).float()
 
-    def get_site_energies(self, graphs: list[CrystalGraph]):
+    def get_site_energies(self, graphs: list[CrystalGraph]) -> list[Tensor]:
         """Predict the site energies given a list of CrystalGraphs.
 
         Args:
@@ -212,7 +213,7 @@ class AtomRef(nn.Module):
         else:
             raise NotImplementedError(f"{dataset=} not supported yet")
 
-    def initialize_from_MPtrj(self) -> None:
+    def initialize_from_MPtrj(self) -> None:  # noqa: N802
         """Initialize pre-fitted weights from MPtrj dataset."""
         state_dict = collections.OrderedDict()
         state_dict["weight"] = torch.tensor(
@@ -317,7 +318,7 @@ class AtomRef(nn.Module):
         self.is_intensive = True
         self.fitted = True
 
-    def initialize_from_MPF(self) -> None:
+    def initialize_from_MPF(self) -> None:  # noqa: N802
         """Initialize pre-fitted weights from MPF dataset."""
         state_dict = collections.OrderedDict()
         state_dict["weight"] = torch.tensor(

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -24,6 +24,7 @@ class CompositionModel(nn.Module):
 
     def __init__(
         self,
+        *,
         atom_fea_dim: int = 64,
         activation: str = "silu",
         is_intensive: bool = True,
@@ -88,7 +89,9 @@ class AtomRef(nn.Module):
     From: https://github.com/materialsvirtuallab/m3gnet/.
     """
 
-    def __init__(self, is_intensive: bool = True, max_num_elements: int = 94) -> None:
+    def __init__(
+        self, *, is_intensive: bool = True, max_num_elements: int = 94
+    ) -> None:
         """Initialize an AtomRef model."""
         super().__init__()
         self.is_intensive = is_intensive

--- a/chgnet/model/composition_model.py
+++ b/chgnet/model/composition_model.py
@@ -202,7 +202,7 @@ class AtomRef(nn.Module):
 
     def initialize_from(self, dataset: str) -> None:
         """Initialize pre-fitted weights from a dataset."""
-        if dataset in ["MPtrj", "MPtrj_e"]:
+        if dataset in {"MPtrj", "MPtrj_e"}:
             self.initialize_from_MPtrj()
         elif dataset == "MPF":
             self.initialize_from_MPF()

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -890,6 +890,6 @@ class EquationOfState:
             return 1 / self.bm.b0
         if unit == "GPa^-1":
             return 1 / self.bm.b0_GPa
-        if unit in ("Pa^-1", "m^2/N"):
+        if unit in {"Pa^-1", "m^2/N"}:
             return 1 / (self.bm.b0_GPa * 1e9)
         raise NotImplementedError("unit has to be one of A^3/eV, GPa^-1 Pa^-1 or m^2/N")

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -94,7 +94,9 @@ class CHGNetCalculator(Calculator):
         print(f"CHGNet will run on {self.device}")
 
     @classmethod
-    def from_file(cls, path: str, use_device: str | None = None, **kwargs):
+    def from_file(
+        cls, path: str, use_device: str | None = None, **kwargs
+    ) -> CHGNetCalculator:
         """Load a user's CHGNet model and initialize the Calculator."""
         return CHGNetCalculator(
             model=CHGNet.from_file(path),
@@ -402,7 +404,7 @@ class CrystalFeasObserver:
 
     def __call__(self) -> None:
         """Record Atoms crystal feature vectors after an MD/relaxation step."""
-        self.crystal_feature_vectors.append(self.atoms._calc.results["crystal_fea"])
+        self.crystal_feature_vectors.append(self.atoms._calc.results["crystal_fea"])  # noqa: SLF001
 
     def __len__(self) -> int:
         """Number of recorded steps."""
@@ -741,7 +743,7 @@ class MolecularDynamics:
             verbose (bool): Whether to notify user about upper-triangular cell
                 transformation. Default = False
         """
-        if not NPT._isuppertriangular(self.atoms.get_cell()):
+        if not NPT._isuppertriangular(self.atoms.get_cell()):  # noqa: SLF001
             a, b, c, alpha, beta, gamma = self.atoms.cell.cellpar()
             angles = np.radians((alpha, beta, gamma))
             sin_a, sin_b, _sin_g = np.sin(angles)

--- a/chgnet/model/dynamics.py
+++ b/chgnet/model/dynamics.py
@@ -55,6 +55,7 @@ class CHGNetCalculator(Calculator):
     def __init__(
         self,
         model: CHGNet | None = None,
+        *,
         use_device: str | None = None,
         check_cuda_mem: bool = True,
         stress_weight: float | None = 1 / 160.21766208,
@@ -215,6 +216,7 @@ class StructOptimizer:
     def relax(
         self,
         atoms: Structure | Atoms,
+        *,
         fmax: float | None = 0.1,
         steps: int | None = 500,
         relax_cell: bool | None = True,
@@ -419,6 +421,7 @@ class MolecularDynamics:
     def __init__(
         self,
         atoms: Atoms | Structure,
+        *,
         model: CHGNet | CHGNetCalculator | None = None,
         ensemble: str = "nvt",
         thermostat: str = "Berendsen_inhomogeneous",
@@ -729,7 +732,7 @@ class MolecularDynamics:
         self.dyn.atoms = atoms
         self.dyn.atoms.calc = calculator
 
-    def upper_triangular_cell(self, verbose: bool | None = False) -> None:
+    def upper_triangular_cell(self, *, verbose: bool | None = False) -> None:
         """Transform to upper-triangular cell.
         ASE Nose-Hoover implementation only supports upper-triangular cell
         while ASE's canonical description is lower-triangular cell.
@@ -799,6 +802,7 @@ class EquationOfState:
     def fit(
         self,
         atoms: Structure | Atoms,
+        *,
         n_points: int = 11,
         fmax: float | None = 0.1,
         steps: int | None = 500,

--- a/chgnet/model/encoders.py
+++ b/chgnet/model/encoders.py
@@ -39,6 +39,7 @@ class BondEncoder(nn.Module):
 
     def __init__(
         self,
+        *,
         atom_graph_cutoff: float = 5,
         bond_graph_cutoff: float = 3,
         num_radial: int = 9,
@@ -113,7 +114,7 @@ class BondEncoder(nn.Module):
 class AngleEncoder(nn.Module):
     """Encode an angle given the two bond vectors using Fourier Expansion."""
 
-    def __init__(self, num_angular: int = 9, learnable: bool = True) -> None:
+    def __init__(self, *, num_angular: int = 9, learnable: bool = True) -> None:
         """Initialize the angle encoder.
 
         Args:

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -94,16 +94,16 @@ class MLP(nn.Module):
             )
         self.layers = nn.Sequential(*layers)
 
-    def forward(self, X: Tensor) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Performs a forward pass through the MLP.
 
         Args:
-            X (Tensor): a tensor of shape (batch_size, input_dim)
+            x (Tensor): a tensor of shape (batch_size, input_dim)
 
         Returns:
             Tensor: a tensor of shape (batch_size, output_dim)
         """
-        return self.layers(X)
+        return self.layers(x)
 
 
 class GatedMLP(nn.Module):
@@ -164,21 +164,21 @@ class GatedMLP(nn.Module):
         self.bn1 = find_normalization(name=norm, dim=output_dim)
         self.bn2 = find_normalization(name=norm, dim=output_dim)
 
-    def forward(self, X: Tensor) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Performs a forward pass through the MLP.
 
         Args:
-            X (Tensor): a tensor of shape (batch_size, input_dim)
+            x (Tensor): a tensor of shape (batch_size, input_dim)
 
         Returns:
             Tensor: a tensor of shape (batch_size, output_dim)
         """
         if self.norm is None:
-            core = self.activation(self.mlp_core(X))
-            gate = self.sigmoid(self.mlp_gate(X))
+            core = self.activation(self.mlp_core(x))
+            gate = self.sigmoid(self.mlp_gate(x))
         else:
-            core = self.activation(self.bn1(self.mlp_core(X)))
-            gate = self.sigmoid(self.bn2(self.mlp_gate(X)))
+            core = self.activation(self.bn1(self.mlp_core(x)))
+            gate = self.sigmoid(self.bn2(self.mlp_gate(x)))
         return core * gate
 
 

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor, nn
 
 
-def aggregate(data: Tensor, owners: Tensor, average=True, num_owner=None) -> Tensor:
+def aggregate(data: Tensor, owners: Tensor, *, average=True, num_owner=None) -> Tensor:
     """Aggregate rows in data by specifying the owners.
 
     Args:
@@ -45,6 +45,7 @@ class MLP(nn.Module):
     def __init__(
         self,
         input_dim: int,
+        *,
         output_dim: int = 1,
         hidden_dim: int | Sequence[int] | None = (64, 64),
         dropout: float = 0,
@@ -114,6 +115,7 @@ class GatedMLP(nn.Module):
         self,
         input_dim: int,
         output_dim: int,
+        *,
         hidden_dim: int | list[int] | None = None,
         dropout: float = 0,
         activation: str = "silu",

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -67,7 +67,7 @@ class MLP(nn.Module):
                 Default = True
         """
         super().__init__()
-        if hidden_dim in (None, 0):
+        if hidden_dim in {None, 0}:
             layers = [nn.Dropout(dropout), nn.Linear(input_dim, output_dim, bias=bias)]
         elif isinstance(hidden_dim, int):
             layers = [

--- a/chgnet/model/functions.py
+++ b/chgnet/model/functions.py
@@ -68,7 +68,7 @@ class MLP(nn.Module):
                 Default = True
         """
         super().__init__()
-        if hidden_dim in {None, 0}:
+        if hidden_dim is None or hidden_dim == 0:
             layers = [nn.Dropout(dropout), nn.Linear(input_dim, output_dim, bias=bias)]
         elif isinstance(hidden_dim, int):
             layers = [

--- a/chgnet/model/layers.py
+++ b/chgnet/model/layers.py
@@ -17,6 +17,7 @@ class AtomConv(nn.Module):
 
     def __init__(
         self,
+        *,
         atom_fea_dim: int,
         bond_fea_dim: int,
         hidden_dim: int = 64,
@@ -144,6 +145,7 @@ class BondConv(nn.Module):
         atom_fea_dim: int,
         bond_fea_dim: int,
         angle_fea_dim: int,
+        *,
         hidden_dim: int = 64,
         dropout: float = 0,
         activation: str = "silu",
@@ -271,6 +273,7 @@ class AngleUpdate(nn.Module):
         atom_fea_dim: int,
         bond_fea_dim: int,
         angle_fea_dim: int,
+        *,
         hidden_dim: int = 0,
         dropout: float = 0,
         activation: str = "silu",
@@ -363,7 +366,7 @@ class AngleUpdate(nn.Module):
 class GraphPooling(nn.Module):
     """Pooling the sub-graphs in the batched graph."""
 
-    def __init__(self, average: bool = False) -> None:
+    def __init__(self, *, average: bool = False) -> None:
         """Args:
         average (bool): whether to average the features.
         """
@@ -392,7 +395,12 @@ class GraphAttentionReadOut(nn.Module):
     """
 
     def __init__(
-        self, atom_fea_dim: int, num_head: int = 3, hidden_dim: int = 32, average=False
+        self,
+        atom_fea_dim: int,
+        num_head: int = 3,
+        hidden_dim: int = 32,
+        *,
+        average=False,
     ) -> None:
         """Initialize the layer.
 

--- a/chgnet/model/layers.py
+++ b/chgnet/model/layers.py
@@ -27,7 +27,7 @@ class AtomConv(nn.Module):
         use_mlp_out: bool = True,
         mlp_out_bias: bool = False,
         resnet: bool = True,
-        gMLP_norm: str | None = None,
+        gMLP_norm: str | None = None,  # noqa: N803
     ) -> None:
         """Initialize the AtomConv layer.
 
@@ -153,7 +153,7 @@ class BondConv(nn.Module):
         use_mlp_out: bool = True,
         mlp_out_bias: bool = False,
         resnet=True,
-        gMLP_norm: str | None = None,
+        gMLP_norm: str | None = None,  # noqa: N803
     ) -> None:
         """Initialize the BondConv layer.
 
@@ -279,7 +279,7 @@ class AngleUpdate(nn.Module):
         activation: str = "silu",
         norm: str | None = None,
         resnet: bool = True,
-        gMLP_norm: str | None = None,
+        gMLP_norm: str | None = None,  # noqa: N803
     ) -> None:
         """Initialize the AngleUpdate layer.
 

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -37,6 +37,7 @@ class CHGNet(nn.Module):
 
     def __init__(
         self,
+        *,
         atom_fea_dim: int = 64,
         bond_fea_dim: int = 64,
         angle_fea_dim: int = 64,
@@ -327,6 +328,7 @@ class CHGNet(nn.Module):
     def forward(
         self,
         graphs: Sequence[CrystalGraph],
+        *,
         task: PredTask = "e",
         return_site_energies: bool = False,
         return_atom_feas: bool = False,
@@ -381,7 +383,8 @@ class CHGNet(nn.Module):
 
     def _compute(
         self,
-        g,
+        g: BatchedGraph,
+        *,
         compute_force: bool = False,
         compute_stress: bool = False,
         compute_magmom: bool = False,
@@ -530,6 +533,7 @@ class CHGNet(nn.Module):
     def predict_structure(
         self,
         structure: Structure | Sequence[Structure],
+        *,
         task: PredTask = "efsm",
         return_site_energies: bool = False,
         return_atom_feas: bool = False,
@@ -578,6 +582,7 @@ class CHGNet(nn.Module):
     def predict_graph(
         self,
         graph: CrystalGraph | Sequence[CrystalGraph],
+        *,
         task: PredTask = "efsm",
         return_site_energies: bool = False,
         return_atom_feas: bool = False,
@@ -671,7 +676,8 @@ class CHGNet(nn.Module):
     @classmethod
     def load(
         cls,
-        model_name="0.3.0",
+        *,
+        model_name: str = "0.3.0",
         use_device: str | None = None,
         check_cuda_mem: bool = True,
         verbose: bool = True,
@@ -769,6 +775,7 @@ class BatchedGraph:
         graphs: Sequence[CrystalGraph],
         bond_basis_expansion: nn.Module,
         angle_basis_expansion: nn.Module,
+        *,
         compute_stress: bool = False,
     ) -> BatchedGraph:
         """Featurize and assemble a list of graphs.

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -150,9 +150,9 @@ class CHGNet(nn.Module):
         """
         # Store model args for reconstruction
         self.model_args = {
-            k: v
-            for k, v in locals().items()
-            if k not in ["self", "__class__", "kwargs"]
+            key: val
+            for key, val in locals().items()
+            if key not in {"self", "__class__", "kwargs"}
         }
         self.model_args.update(kwargs)
         if version:
@@ -279,7 +279,7 @@ class CHGNet(nn.Module):
             self.read_out_type = "sum"
             input_dim = atom_fea_dim
             self.pooling = GraphPooling(average=False)
-        elif read_out in ["attn", "weighted"]:
+        elif read_out in {"attn", "weighted"}:
             self.read_out_type = "attn"
             num_heads = kwargs.pop("num_heads", 3)
             self.pooling = GraphAttentionReadOut(
@@ -290,7 +290,7 @@ class CHGNet(nn.Module):
             self.read_out_type = "ave"
             input_dim = atom_fea_dim
             self.pooling = GraphPooling(average=True)
-        if kwargs.pop("final_mlp", "MLP") in ["normal", "MLP"]:
+        if kwargs.pop("final_mlp", "MLP") in {"normal", "MLP"}:
             self.mlp = MLP(
                 input_dim=input_dim,
                 hidden_dim=mlp_hidden_dims,

--- a/chgnet/model/model.py
+++ b/chgnet/model/model.py
@@ -62,7 +62,7 @@ class CHGNet(nn.Module):
         graph_converter_algorithm: Literal["legacy", "fast"] = "fast",
         cutoff_coeff: int = 8,
         learnable_rbf: bool = True,
-        gMLP_norm: str | None = "layer",
+        gMLP_norm: str | None = "layer",  # noqa: N803
         readout_norm: str | None = "layer",
         version: str | None = None,
         **kwargs,
@@ -613,7 +613,7 @@ class CHGNet(nn.Module):
                     magneton mu_B
         """
         if not isinstance(graph, (CrystalGraph, Sequence)):
-            raise ValueError(
+            raise TypeError(
                 f"{type(graph)=} must be CrystalGraph or list of CrystalGraphs"
             )
 

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -475,7 +475,7 @@ class Trainer:
         """Get best model recorded in the trainer."""
         if self.best_model is None:
             raise RuntimeError("the model needs to be trained first")
-        MAE = min(self.training_history["e"]["val"])
+        MAE = min(self.training_history["e"]["val"])  # noqa: N806
         print(f"Best model has val {MAE =:.4}")
         return self.best_model
 

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -93,7 +93,7 @@ class Trainer:
         self.trainer_args = {
             k: v
             for k, v in locals().items()
-            if k not in ["self", "__class__", "model", "kwargs"]
+            if k not in {"self", "__class__", "model", "kwargs"}
         }
         self.trainer_args.update(kwargs)
 
@@ -132,7 +132,7 @@ class Trainer:
             )
 
         # Define learning rate scheduler
-        if scheduler in ["MultiStepLR", "multistep"]:
+        if scheduler in {"MultiStepLR", "multistep"}:
             scheduler_params = kwargs.pop(
                 "scheduler_params",
                 {
@@ -142,11 +142,11 @@ class Trainer:
             )
             self.scheduler = MultiStepLR(self.optimizer, **scheduler_params)
             self.scheduler_type = "multistep"
-        elif scheduler in ["ExponentialLR", "Exp", "Exponential"]:
+        elif scheduler in {"ExponentialLR", "Exp", "Exponential"}:
             scheduler_params = kwargs.pop("scheduler_params", {"gamma": 0.98})
             self.scheduler = ExponentialLR(self.optimizer, **scheduler_params)
             self.scheduler_type = "exp"
-        elif scheduler in ["CosineAnnealingLR", "CosLR", "Cos", "cos"]:
+        elif scheduler in {"CosineAnnealingLR", "CosLR", "Cos", "cos"}:
             scheduler_params = kwargs.pop("scheduler_params", {"decay_fraction": 1e-2})
             decay_fraction = scheduler_params.pop("decay_fraction")
             self.scheduler = CosineAnnealingLR(
@@ -481,7 +481,7 @@ class Trainer:
         return [
             key
             for key in list(inspect.signature(Trainer.__init__).parameters)
-            if key not in (["self", "model", "kwargs"])
+            if key not in {"self", "model", "kwargs"}
         ]
 
     def save(self, filename: str = "training_result.pth.tar") -> None:
@@ -602,9 +602,9 @@ class CombinedLoss(nn.Module):
         """
         super().__init__()
         # Define loss criterion
-        if criterion in ["MSE", "mse"]:
+        if criterion in {"MSE", "mse"}:
             self.criterion = nn.MSELoss()
-        elif criterion in ["MAE", "mae", "l1"]:
+        elif criterion in {"MAE", "mae", "l1"}:
             self.criterion = nn.L1Loss()
         elif criterion == "Huber":
             self.criterion = nn.HuberLoss(delta=delta)

--- a/chgnet/trainer/trainer.py
+++ b/chgnet/trainer/trainer.py
@@ -33,6 +33,7 @@ class Trainer:
     def __init__(
         self,
         model: CHGNet | None = None,
+        *,
         targets: TrainTask = "ef",
         energy_loss_ratio: float = 1,
         force_loss_ratio: float = 1,
@@ -199,6 +200,7 @@ class Trainer:
         train_loader: DataLoader,
         val_loader: DataLoader,
         test_loader: DataLoader | None = None,
+        *,
         save_dir: str | None = None,
         save_test_result: bool = False,
         train_composition_model: bool = False,
@@ -353,6 +355,7 @@ class Trainer:
     def _validate(
         self,
         val_loader: DataLoader,
+        *,
         is_test: bool = False,
         test_result_save_path: str | None = None,
     ) -> dict:
@@ -572,6 +575,7 @@ class CombinedLoss(nn.Module):
 
     def __init__(
         self,
+        *,
         target_str: str = "ef",
         criterion: str = "MSE",
         is_intensive: bool = True,

--- a/chgnet/utils/common_utils.py
+++ b/chgnet/utils/common_utils.py
@@ -12,7 +12,7 @@ def determine_device(
     use_device: str | None = None,
     *,
     check_cuda_mem: bool = True,
-):
+) -> str:
     """Determine the device to use for torch model.
 
     Args:

--- a/chgnet/utils/common_utils.py
+++ b/chgnet/utils/common_utils.py
@@ -22,7 +22,7 @@ def determine_device(
         device (str): device name to be passed to model.to(device)
     """
     use_device = use_device or os.getenv("CHGNET_DEVICE")
-    if use_device in ("mps", None) and torch.backends.mps.is_available():
+    if use_device in {"mps", None} and torch.backends.mps.is_available():
         device = "mps"
     else:
         device = use_device or ("cuda" if torch.cuda.is_available() else "cpu")

--- a/chgnet/utils/common_utils.py
+++ b/chgnet/utils/common_utils.py
@@ -10,6 +10,7 @@ from torch import Tensor
 
 def determine_device(
     use_device: str | None = None,
+    *,
     check_cuda_mem: bool = True,
 ):
     """Determine the device to use for torch model.

--- a/chgnet/utils/vasp_utils.py
+++ b/chgnet/utils/vasp_utils.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 def parse_vasp_dir(
     base_dir: str,
+    *,
     check_electronic_convergence: bool = True,
     save_path: str | None = None,
 ) -> dict[str, list]:

--- a/examples/make_graphs.py
+++ b/examples/make_graphs.py
@@ -71,7 +71,7 @@ def make_one_graph(mp_id: str, graph_id: str, data, graph_dir) -> dict | bool:
 
 
 def make_partition(
-    data, graph_dir, train_ratio=0.8, val_ratio=0.1, partition_with_frame=False
+    data, graph_dir, train_ratio=0.8, val_ratio=0.1, *, partition_with_frame=False
 ) -> None:
     """Make a train val test partition."""
     random.seed(42)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,41 +52,12 @@ find = { include = ["chgnet*"], exclude = ["tests", "tests*"] }
 target-version = "py39"
 include = ["**/pyproject.toml", "*.ipynb", "*.py", "*.pyi"]
 [tool.ruff.lint]
-select = [
-    "B",    # flake8-bugbear
-    "C4",   # flake8-comprehensions
-    "D",    # pydocstyle
-    "E",    # pycodestyle error
-    "EXE",  # flake8-executable
-    "F",    # pyflakes
-    "FA",   # flake8-future-annotations
-    "FLY",  # flynt
-    "I",    # isort
-    "ICN",  # flake8-import-conventions
-    "ISC",  # flake8-implicit-str-concat
-    "PD",   # pandas-vet
-    "PERF", # perflint
-    "PIE",  # flake8-pie
-    "PL",   # pylint
-    "PT",   # flake8-pytest-style
-    "PYI",  # flakes8-pyi
-    "Q",    # flake8-quotes
-    "RET",  # flake8-return
-    "RSE",  # flake8-raise
-    "RUF",  # Ruff-specific rules
-    "SIM",  # flake8-simplify
-    "SLOT", # flakes8-slot
-    "T201",
-    "TCH",  # flake8-type-checking
-    "TID",  # tidy imports
-    "TID",  # flake8-tidy-imports
-    "UP",   # pyupgrade
-    "W",    # pycodestyle warning
-    "YTT",  # flake8-2020
-]
+select = ["ALL"]
 ignore = [
     "ANN001",  # TODO add missing type annotations
     "ANN003",
+    "ANN101",
+    "ANN102",
     "B019",    # Use of functools.lru_cache on methods can lead to memory leaks
     "BLE001",
     "C408",    # unnecessary-collection-call
@@ -108,9 +79,12 @@ ignore = [
     "PT013",   # pytest-incorrect-pytest-import
     "PT019",   # pytest-fixture-param-without-value
     "PTH",     # prefer Path to os.path
+    "S108",
     "S301",    # pickle can be unsafe
     "S310",
+    "S311",
     "TRY003",
+    "TRY300",
 ]
 pydocstyle.convention = "google"
 isort.required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ ignore = [
     "E731",    # do not assign a lambda expression, use a def
     "EM",
     "ERA001",  # found commented out code
-    "FBT001",  # Boolean positional argument in function
-    "FBT002",  # Boolean keyword argument in function
     "ISC001",
     "NPY002",  # TODO replace legacy np.random.seed
     "PLR",     # pylint refactor
@@ -120,7 +118,7 @@ isort.split-on-trailing-comma = false
 
 [tool.ruff.lint.per-file-ignores]
 "site/*" = ["INP001", "S602"]
-"tests/*" = ["ANN201", "D103", "INP001", "S101"]
+"tests/*" = ["ANN201", "D100", "D103", "FBT001", "FBT002", "INP001", "S101"]
 # E402 Module level import not at top of file
 "examples/*" = ["E402", "I002", "INP001", "N816", "S101", "T201"]
 "chgnet/**/*" = ["T201"]


### PR DESCRIPTION
`ALL` `ruff` rules now enabled unless specifically ignored

@BowenD-UCB needs approval given some of this is strictly speaking breaking.

- some exception types changed from `ValueError` to `TypeError`
- some boolean arguments that could be passed as positional before can now only be passed as keywords.
  
  example:
  ```py
  # considered bad practice due to being unreadable, who knows what False means here
  CHGNetCalculator(some_model, some_device, False)
  
  # more readable to pass booleans as keywords, only this works now
  CHGNetCalculator(some_model, some_device, check_cuda_mem=False)
  ```