### PR TITLE
Fix missing `create_graph.c` in source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ find = { include = ["chgnet*"], exclude = ["tests", "tests*"] }
 
 [tool.setuptools.package-data]
 "chgnet" = ["*.json", "py.typed"]
+"chgnet.graph.fast_converter_libraries" = ["*"]
 "chgnet.pretrained" = ["*", "**/*"]
 
 [build-system]


### PR DESCRIPTION
### Summary

- Fix missing `create_graph.c` in source distribution

I believe this really fixes #160 where `create_graph.c` is missing from sdist, in other words, sdist should be installable alone, and wheels should not replace sdist.