### PR TITLE
Remove reverse readline, test again NP1 and recover NumPy 1 dependency support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
           pip install uv
           uv pip install -e .[test,logging] --resolution=${{ matrix.version.resolution }} --system
 
-          # TODO: test monty fix for reverse readline
-          uv pip install git+https://github.com/DanielYang59/monty.git@readline-line-ending --system
-
       - name: Run Tests
         run: pytest --capture=no --cov --cov-report=xml
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
           pip install uv
           uv pip install -e .[test,logging] --resolution=${{ matrix.version.resolution }} --system
 
-          # TODO: remove pin once reverse readline fixed
-          uv pip install monty==2024.7.12 --system
+          # TODO: test monty fix for reverse readline
+          pip install git+https://github.com/DanielYang59/monty.git@readline-line-ending
 
       - name: Run Tests
         run: pytest --capture=no --cov --cov-report=xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           uv pip install -e .[test,logging] --resolution=${{ matrix.version.resolution }} --system
 
           # TODO: test monty fix for reverse readline
-          pip install git+https://github.com/DanielYang59/monty.git@readline-line-ending
+          uv pip install git+https://github.com/DanielYang59/monty.git@readline-line-ending --system
 
       - name: Run Tests
         run: pytest --capture=no --cov --cov-report=xml

--- a/chgnet/utils/vasp_utils.py
+++ b/chgnet/utils/vasp_utils.py
@@ -61,7 +61,7 @@ def parse_vasp_dir(
     charge, mag_x, mag_y, mag_z, header = [], [], [], [], []
 
     with zopen(outcar_path, encoding="utf-8") as file:
-        all_lines = [line.strip() for line in file]
+        all_lines = [line.strip() for line in file.readlines()]
 
     # For single atom systems, VASP doesn't print a total line, so
     # reverse parsing is very difficult

--- a/chgnet/utils/vasp_utils.py
+++ b/chgnet/utils/vasp_utils.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING
 
-from monty.io import reverse_readfile
+from monty.io import zopen
 from monty.os.path import zpath
 from pymatgen.io.vasp.outputs import Oszicar, Vasprun
 
@@ -58,13 +58,11 @@ def parse_vasp_dir(
         exception_on_bad_xml=False,
     )
 
-    charge, mag_x, mag_y, mag_z, header, all_lines = [], [], [], [], [], []
+    charge, mag_x, mag_y, mag_z, header = [], [], [], [], []
 
-    for line in reverse_readfile(outcar_path):
-        clean = line.strip()
-        all_lines.append(clean)
+    with zopen(outcar_path, encoding="utf-8") as file:
+        all_lines = [line.strip() for line in file]
 
-    all_lines.reverse()
     # For single atom systems, VASP doesn't print a total line, so
     # reverse parsing is very difficult
     # for SOC calculations only
@@ -79,23 +77,21 @@ def parse_vasp_dir(
             if clean.startswith("# of ion"):
                 header = re.split(r"\s{2,}", clean.strip())
                 header.pop(0)
-            else:
-                m = re.match(r"\s*(\d+)\s+(([\d\.\-]+)\s+)+", clean)
-                if m:
-                    tokens = [float(token) for token in re.findall(r"[\d\.\-]+", clean)]
-                    tokens.pop(0)
-                    if read_charge:
-                        charge.append(dict(zip(header, tokens)))
-                    elif read_mag_x:
-                        mag_x.append(dict(zip(header, tokens)))
-                    elif read_mag_y:
-                        mag_y.append(dict(zip(header, tokens)))
-                    elif read_mag_z:
-                        mag_z.append(dict(zip(header, tokens)))
-                elif clean.startswith("tot"):
-                    if ion_step_count == (len(mag_x_all) + 1):
-                        mag_x_all.append(mag_x)
-                    read_charge = read_mag_x = read_mag_y = read_mag_z = False
+            elif re.match(r"\s*(\d+)\s+(([\d\.\-]+)\s+)+", clean):
+                tokens = [float(token) for token in re.findall(r"[\d\.\-]+", clean)]
+                tokens.pop(0)
+                if read_charge:
+                    charge.append(dict(zip(header, tokens)))
+                elif read_mag_x:
+                    mag_x.append(dict(zip(header, tokens)))
+                elif read_mag_y:
+                    mag_y.append(dict(zip(header, tokens)))
+                elif read_mag_z:
+                    mag_z.append(dict(zip(header, tokens)))
+            elif clean.startswith("tot"):
+                if ion_step_count == (len(mag_x_all) + 1):
+                    mag_x_all.append(mag_x)
+                read_charge = read_mag_x = read_mag_y = read_mag_z = False
         if clean == "total charge":
             read_charge = True
             read_mag_x = read_mag_y = read_mag_z = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ license = { text = "Modified BSD" }
 dependencies = [
     "ase>=3.23.0",
     "cython>=3",
-    # "monty==2024.7.12",  # TODO: restore once readline fixed
     # "numpy>=1.26",  # TODO: remove after test
     "numpy>=2.0.0",
     "nvidia-ml-py3>=7.352.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "ase>=3.23.0",
     "cython>=3",
     # "numpy>=1.26",  # TODO: remove after test
-    "numpy>=2.0.0",
+    "numpy==1.26",
     "nvidia-ml-py3>=7.352.0",
     "pymatgen>=2024.9.10",
     "torch>=2.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ license = { text = "Modified BSD" }
 dependencies = [
     "ase>=3.23.0",
     "cython>=3",
-    # "numpy>=1.26",  # TODO: remove after test
-    "numpy==1.26",
+    "numpy>=1.26",
     "nvidia-ml-py3>=7.352.0",
     "pymatgen>=2024.9.10",
     "torch>=2.4.1",


### PR DESCRIPTION
### Summary

- Replace `monty` `reverse_readline` with built in `readline`
- [x] release `numpy >2` pin 
- [x] test numpy 1 https://github.com/CederGroupHub/chgnet/pull/203/checks?check_run_id=30164697551

I'm not seeing much point in using `reverse_readline` as all lines are read, and reversed immediately: https://github.com/CederGroupHub/chgnet/blob/11ff51384fef09bfab999e45b519410eb6fd2c12/chgnet/utils/vasp_utils.py#L61-L67