### PR TITLE
Fix FutureWarning in vasp_utils.py

### DIFF
--- a/chgnet/utils/vasp_utils.py
+++ b/chgnet/utils/vasp_utils.py
@@ -60,7 +60,7 @@ def parse_vasp_dir(
 
     charge, mag_x, mag_y, mag_z, header = [], [], [], [], []
 
-    with zopen(outcar_path, encoding="utf-8") as file:
+    with zopen(outcar_path, mode="rt", encoding="utf-8") as file:
         all_lines = [line.strip() for line in file.readlines()]
 
     # For single atom systems, VASP doesn't print a total line, so


### PR DESCRIPTION
When parsing VASP directories using `parse_vasp_dir`, a FutureWarning appears: `FutureWarning: We strongly discourage using a default `mode`, it would be set to `r` now but would not be allowed after 2025-06-01`

Suggested fix:
Add explicit `mode='rt'` parameter to `zopen()` call in vasp_utils.py

